### PR TITLE
Add price customization sliders and fix simulated order submission

### DIFF
--- a/account_detector.py
+++ b/account_detector.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Account Detection Module
+Handles detection and management of multiple Robinhood accounts (Regular, Roth IRA, etc.)
+"""
+
+import robin_stocks.robinhood as r
+from typing import Dict, List, Optional
+import logging
+
+class AccountDetector:
+    """Detects and manages information about available Robinhood accounts"""
+    
+    def __init__(self):
+        self.logger = logging.getLogger('account_detector')
+        self._accounts_cache = None
+        self._account_prefix_map = {}  # Maps account_prefix -> full_account_number
+    
+    def _generate_account_prefix(self, account_number: str, account_type: str) -> str:
+        """Generate a safe account prefix from type and last 4 digits"""
+        last_four = account_number[-4:]
+        
+        # Map account types to short prefixes
+        type_prefixes = {
+            'Standard': 'STD',
+            'Roth IRA': 'ROTH', 
+            'Traditional IRA': 'TRAD',
+            'Cash': 'CASH'
+        }
+        
+        prefix = type_prefixes.get(account_type, 'ACC')
+        return f"{prefix}-{last_four}"
+    
+    def get_account_number_from_prefix(self, account_prefix: str) -> Optional[str]:
+        """Get full account number from account prefix"""
+        return self._account_prefix_map.get(account_prefix)
+    
+    def detect_accounts(self, force_refresh: bool = False) -> Dict[str, Dict]:
+        """
+        Detect all available Robinhood accounts
+        
+        Args:
+            force_refresh: Force refresh of cached account data
+            
+        Returns:
+            Dict with account_number as key and account info as value
+        """
+        if self._accounts_cache and not force_refresh:
+            return self._accounts_cache
+            
+        try:
+            self.logger.info("Detecting available Robinhood accounts...")
+            
+            # Get all accounts using robin-stocks
+            all_accounts_data = r.load_account_profile(dataType="regular")
+            
+            if not all_accounts_data or 'results' not in all_accounts_data:
+                self.logger.error("Failed to retrieve account data from Robinhood")
+                return {}
+            
+            accounts = {}
+            for account_data in all_accounts_data['results']:
+                account_number = account_data.get('account_number')
+                if not account_number:
+                    continue
+                    
+                # Only include active accounts
+                if account_data.get('state') != 'active':
+                    self.logger.warning(f"Skipping inactive account: {account_number[-4:]}")
+                    continue
+                
+                # Determine account type
+                account_type = account_data.get('type', 'Standard')
+                
+                # Generate account prefix (e.g., STD-1234, ROTH-5678)
+                account_prefix = self._generate_account_prefix(account_number, account_type)
+                
+                # Store mapping from prefix to full account number
+                self._account_prefix_map[account_prefix] = account_number
+                
+                # Create display name with last 4 digits
+                display_name = f"{account_type} (...{account_number[-4:]})"
+                
+                accounts[account_prefix] = {
+                    'number': account_number,
+                    'prefix': account_prefix,
+                    'type': account_type,
+                    'display_name': display_name,
+                    'state': account_data.get('state', 'unknown'),
+                    'raw_data': account_data
+                }
+                
+                self.logger.info(f"Found account: {display_name}")
+            
+            self._accounts_cache = accounts
+            self.logger.info(f"Successfully detected {len(accounts)} active account(s)")
+            return accounts
+            
+        except Exception as e:
+            self.logger.error(f"Error detecting accounts: {e}")
+            return {}
+    
+    def has_positions_or_orders(self, account_identifier: str) -> bool:
+        """
+        Check if an account has open positions
+        
+        Args:
+            account_identifier: Either account prefix (STD-1234) or full account number
+            
+        Returns:
+            True if account has positions, False otherwise
+        """
+        # Convert prefix to full account number if needed
+        if '-' in account_identifier and len(account_identifier) <= 10:
+            account_number = self.get_account_number_from_prefix(account_identifier)
+            if not account_number:
+                self.logger.error(f"Account prefix not found: {account_identifier}")
+                return False
+        else:
+            account_number = account_identifier
+        try:
+            # Check for open option positions (efficient - no historical data)
+            option_positions = r.get_open_option_positions(account_number=account_number)
+            if option_positions and len(option_positions) > 0:
+                self.logger.info(f"Account ...{account_number[-4:]} has {len(option_positions)} open option positions")
+                return True
+                
+            # Check for open stock positions
+            stock_positions = r.get_open_stock_positions(account_number=account_number)
+            if stock_positions and len(stock_positions) > 0:
+                self.logger.info(f"Account ...{account_number[-4:]} has {len(stock_positions)} open stock positions")
+                return True
+                
+            self.logger.info(f"Account ...{account_number[-4:]} has no open positions")
+            return False
+            
+        except Exception as e:
+            self.logger.error(f"Error checking positions for account ...{account_number[-4:]}: {e}")
+            return False
+    
+    def get_active_accounts(self) -> Dict[str, Dict]:
+        """
+        Get accounts that have positions or orders (should have active risk managers)
+        
+        Returns:
+            Dict of accounts that should have active risk managers
+        """
+        all_accounts = self.detect_accounts()
+        active_accounts = {}
+        
+        for account_prefix, account_info in all_accounts.items():
+            if self.has_positions_or_orders(account_prefix):
+                active_accounts[account_prefix] = account_info
+                self.logger.info(f"Account {account_info['display_name']} marked as active")
+        
+        return active_accounts
+    
+    def get_account_info(self, account_identifier: str) -> Optional[Dict]:
+        """
+        Get information for a specific account
+        
+        Args:
+            account_identifier: Either account prefix (STD-1234) or full account number
+            
+        Returns:
+            Account info dict or None if not found
+        """
+        accounts = self.detect_accounts()
+        
+        # If it looks like a prefix, use it directly
+        if '-' in account_identifier and len(account_identifier) <= 10:
+            return accounts.get(account_identifier)
+        
+        # Otherwise, find by full account number
+        for account_prefix, account_info in accounts.items():
+            if account_info['number'] == account_identifier:
+                return account_info
+        
+        return None
+    
+    def list_accounts_summary(self) -> str:
+        """
+        Generate a summary string of all detected accounts
+        
+        Returns:
+            Formatted string summarizing all accounts
+        """
+        accounts = self.detect_accounts()
+        if not accounts:
+            return "No accounts detected"
+        
+        summary = f"Detected {len(accounts)} account(s):\n"
+        for account_number, info in accounts.items():
+            has_activity = "✓" if self.has_positions_or_orders(account_number) else "○"
+            summary += f"  {has_activity} {info['display_name']} - {info['state']}\n"
+        
+        return summary.strip()

--- a/multi_account_manager.py
+++ b/multi_account_manager.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Multi-Account Risk Manager
+Orchestrates multiple isolated BaseRiskManager instances for different Robinhood accounts
+"""
+
+import robin_stocks.robinhood as r
+from account_detector import AccountDetector
+from base_risk_manager import BaseRiskManager
+import threading
+import time
+import logging
+from typing import Dict, Optional
+from datetime import datetime
+import pytz
+
+class AccountMonitoringThread:
+    """Handles monitoring for a single account"""
+    
+    def __init__(self, account_number: str, account_info: Dict, stop_loss_percent: float = 50.0):
+        self.account_number = account_number
+        self.account_info = account_info
+        self.risk_manager = BaseRiskManager(
+            stop_loss_percent=stop_loss_percent,
+            account_number=account_number
+        )
+        self.thread = None
+        self.stop_event = threading.Event()
+        self.logger = logging.getLogger(f'account_monitor_{account_number[-4:]}')
+        
+    def start_monitoring(self):
+        """Start the monitoring thread"""
+        if self.thread is None or not self.thread.is_alive():
+            self.stop_event.clear()
+            self.thread = threading.Thread(
+                target=self.monitoring_loop,
+                name=f"AccountMonitor-{self.account_number[-4:]}",
+                daemon=True
+            )
+            self.thread.start()
+            self.logger.info(f"Started monitoring for account {self.account_info['display_name']}")
+    
+    def stop_monitoring(self):
+        """Stop the monitoring thread"""
+        if self.thread and self.thread.is_alive():
+            self.stop_event.set()
+            self.thread.join(timeout=5)
+            self.logger.info(f"Stopped monitoring for account {self.account_info['display_name']}")
+    
+    def monitoring_loop(self):
+        """Main monitoring loop - runs independently per account"""
+        et_tz = pytz.timezone('US/Eastern')
+        
+        # Load positions once at start of monitoring
+        self.logger.info(f"Loading positions for account {self.account_info['display_name']}")
+        self.risk_manager.login_robinhood()
+        position_count = self.risk_manager.load_long_positions()
+        
+        if position_count == 0:
+            self.logger.info(f"No positions found for account {self.account_info['display_name']}, stopping monitoring")
+            return
+            
+        self.logger.info(f"Monitoring {position_count} positions for account {self.account_info['display_name']}")
+        
+        while not self.stop_event.is_set():
+            try:
+                now_et = datetime.now(et_tz)
+                current_time = now_et.time()
+                
+                # Market hours: 9:30 AM - 4:00 PM ET
+                market_start = current_time.replace(hour=9, minute=30, second=0)
+                market_end = current_time.replace(hour=16, minute=0, second=0)
+                is_market_hours = market_start <= current_time <= market_end
+                is_weekday = now_et.weekday() < 5  # Monday = 0, Sunday = 6
+                
+                if is_market_hours and is_weekday:
+                    # High frequency updates during market hours only
+                    self.risk_manager.check_trailing_stops()
+                    time.sleep(1)  # 1-second updates during market hours
+                else:
+                    # Just check every minute if market has opened yet
+                    time.sleep(60)  # 1-minute check when market is closed
+                    
+            except Exception as e:
+                self.logger.error(f"Error in monitoring loop for account {self.account_number[-4:]}: {e}")
+                time.sleep(5)  # Brief pause on error
+
+class MultiAccountRiskManager:
+    """Manages multiple isolated risk manager instances"""
+    
+    def __init__(self):
+        self.logger = logging.getLogger('multi_account_manager')
+        self.account_detector = AccountDetector()
+        self.monitoring_threads: Dict[str, AccountMonitoringThread] = {}
+        self._lock = threading.Lock()
+    
+    def initialize_accounts(self, force_refresh: bool = False) -> Dict[str, Dict]:
+        """Initialize and detect all available accounts"""
+        try:
+            accounts = self.account_detector.detect_accounts(force_refresh=force_refresh)
+            self.logger.info(f"Initialized {len(accounts)} account(s)")
+            return accounts
+        except Exception as e:
+            self.logger.error(f"Error initializing accounts: {e}")
+            return {}
+    
+    def get_active_accounts(self) -> Dict[str, Dict]:
+        """Get accounts that have positions or orders"""
+        return self.account_detector.get_active_accounts()
+    
+    def start_account_monitoring(self, account_number: str, stop_loss_percent: float = 50.0):
+        """Start monitoring for a specific account"""
+        with self._lock:
+            account_info = self.account_detector.get_account_info(account_number)
+            if not account_info:
+                self.logger.error(f"Account not found: {account_number[-4:]}")
+                return False
+            
+            # Stop existing monitoring if running
+            if account_number in self.monitoring_threads:
+                self.monitoring_threads[account_number].stop_monitoring()
+            
+            # Create and start new monitoring thread
+            monitor = AccountMonitoringThread(account_number, account_info, stop_loss_percent)
+            monitor.start_monitoring()
+            self.monitoring_threads[account_number] = monitor
+            
+            self.logger.info(f"Started monitoring for {account_info['display_name']}")
+            return True
+    
+    def stop_account_monitoring(self, account_number: str):
+        """Stop monitoring for a specific account"""
+        with self._lock:
+            if account_number in self.monitoring_threads:
+                self.monitoring_threads[account_number].stop_monitoring()
+                del self.monitoring_threads[account_number]
+                self.logger.info(f"Stopped monitoring for account ...{account_number[-4:]}")
+    
+    def auto_start_active_accounts(self, stop_loss_percent: float = 50.0):
+        """Automatically start monitoring for all accounts with positions/orders"""
+        active_accounts = self.get_active_accounts()
+        
+        for account_number, account_info in active_accounts.items():
+            self.start_account_monitoring(account_number, stop_loss_percent)
+            
+        self.logger.info(f"Auto-started monitoring for {len(active_accounts)} active account(s)")
+        return len(active_accounts)
+    
+    def stop_all_monitoring(self):
+        """Stop monitoring for all accounts"""
+        with self._lock:
+            for account_number in list(self.monitoring_threads.keys()):
+                self.monitoring_threads[account_number].stop_monitoring()
+            self.monitoring_threads.clear()
+            self.logger.info("Stopped all account monitoring")
+    
+    def get_account_risk_manager(self, account_number: str) -> Optional[BaseRiskManager]:
+        """Get the risk manager instance for a specific account"""
+        if account_number in self.monitoring_threads:
+            return self.monitoring_threads[account_number].risk_manager
+        return None
+    
+    def get_monitoring_status(self) -> Dict[str, Dict]:
+        """Get status of all monitored accounts"""
+        status = {}
+        for account_number, monitor in self.monitoring_threads.items():
+            account_info = self.account_detector.get_account_info(account_number)
+            is_alive = monitor.thread and monitor.thread.is_alive()
+            
+            status[account_number] = {
+                'display_name': account_info['display_name'] if account_info else f"...{account_number[-4:]}",
+                'monitoring_active': is_alive,
+                'thread_name': monitor.thread.name if monitor.thread else None,
+                'account_type': account_info['type'] if account_info else 'Unknown'
+            }
+        
+        return status
+    
+    def list_accounts_summary(self) -> str:
+        """Generate a summary of all accounts and their monitoring status"""
+        accounts = self.account_detector.detect_accounts()
+        if not accounts:
+            return "No accounts detected"
+        
+        summary = f"Multi-Account Risk Manager Status ({len(accounts)} account(s)):\n"
+        for account_number, info in accounts.items():
+            monitoring_status = "🟢 Active" if account_number in self.monitoring_threads else "○ Inactive"
+            has_activity = "✓" if self.account_detector.has_positions_or_orders(account_number) else "○"
+            summary += f"  {has_activity} {info['display_name']} - {info['state']} - {monitoring_status}\n"
+        
+        return summary.strip()

--- a/templates/account_selector.html
+++ b/templates/account_selector.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Multi-Account Risk Manager</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+    <style>
+        .account-card {
+            border: 2px solid #dee2e6;
+            border-radius: 12px;
+            transition: all 0.3s ease;
+            cursor: pointer;
+            min-height: 180px;
+        }
+        
+        .account-card:hover {
+            border-color: #0d6efd;
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+        
+        .account-card.active {
+            border-color: #198754;
+            background-color: #f8fff9;
+        }
+        
+        .account-card.inactive {
+            border-color: #6c757d;
+            background-color: #f8f9fa;
+        }
+        
+        .account-type-badge {
+            font-size: 0.9rem;
+            font-weight: 600;
+        }
+        
+        .account-number {
+            font-family: monospace;
+            font-size: 0.95rem;
+            color: #6c757d;
+        }
+        
+        .activity-indicator {
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            display: inline-block;
+            margin-right: 6px;
+        }
+        
+        .activity-indicator.active {
+            background-color: #198754;
+        }
+        
+        .activity-indicator.inactive {
+            background-color: #6c757d;
+        }
+        
+        .trading-mode-banner {
+            background: linear-gradient(45deg, #ff6b6b, #ffa500);
+            color: white;
+            font-weight: bold;
+        }
+        
+        .simulation-mode-banner {
+            background: linear-gradient(45deg, #4ecdc4, #45b7d1);
+            color: white;
+            font-weight: bold;
+        }
+        
+        .header-title {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body class="bg-light">
+    <!-- Mode Banner -->
+    <div class="{% if live_trading_mode %}trading-mode-banner{% else %}simulation-mode-banner{% endif %} text-center py-2">
+        {% if live_trading_mode %}
+            <i class="bi bi-fire"></i> LIVE TRADING MODE - Real orders will be placed
+        {% else %}
+            <i class="bi bi-shield-check"></i> SIMULATION MODE - No real orders
+        {% endif %}
+    </div>
+
+    <div class="container my-5">
+        <!-- Header -->
+        <div class="text-center mb-5">
+            <h1 class="display-4 header-title mb-3">
+                <i class="bi bi-graph-up-arrow"></i> Multi-Account Risk Manager
+            </h1>
+            <p class="lead text-muted">Select an account to monitor and manage option positions</p>
+        </div>
+
+        <!-- Accounts Grid -->
+        <div class="row g-4">
+            {% for account_prefix, account_info in accounts.items() %}
+            <div class="col-md-6 col-lg-4">
+                <div class="card account-card h-100 {% if account_info.has_activity %}active{% else %}inactive{% endif %}"
+                     onclick="window.location.href='/account/{{ account_prefix }}'">
+                    <div class="card-body d-flex flex-column">
+                        <!-- Account Type Badge -->
+                        <div class="mb-3">
+                            <span class="badge account-type-badge
+                                {% if account_info.type == 'Roth IRA' %}bg-success{% elif account_info.type == 'Traditional IRA' %}bg-info{% else %}bg-primary{% endif %}">
+                                {% if account_info.type == 'Roth IRA' %}
+                                    <i class="bi bi-piggy-bank"></i> {{ account_info.type }}
+                                {% elif account_info.type == 'Traditional IRA' %}
+                                    <i class="bi bi-bank"></i> {{ account_info.type }}
+                                {% else %}
+                                    <i class="bi bi-wallet2"></i> {{ account_info.type }}
+                                {% endif %}
+                            </span>
+                        </div>
+
+                        <!-- Account Display Name -->
+                        <h5 class="card-title mb-2">
+                            {{ account_info.display_name }}
+                        </h5>
+
+                        <!-- Account Number -->
+                        <p class="account-number mb-3">
+                            Account: {{ account_info.number[-8:] }}
+                        </p>
+
+                        <!-- Status and Activity -->
+                        <div class="mt-auto">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <small class="text-muted">
+                                    <span class="activity-indicator {% if account_info.has_activity %}active{% else %}inactive{% endif %}"></span>
+                                    {% if account_info.has_activity %}
+                                        Has Positions/Orders
+                                    {% else %}
+                                        No Active Positions
+                                    {% endif %}
+                                </small>
+                                <small class="text-muted">
+                                    {{ account_info.state|title }}
+                                </small>
+                            </div>
+                            
+                            <!-- Action Button -->
+                            <div class="text-center">
+                                {% if account_info.has_activity %}
+                                    <span class="btn btn-success btn-sm">
+                                        <i class="bi bi-arrow-right-circle"></i> Monitor Positions
+                                    </span>
+                                {% else %}
+                                    <span class="btn btn-outline-secondary btn-sm">
+                                        <i class="bi bi-eye"></i> View Account
+                                    </span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+
+        <!-- No Accounts Message -->
+        {% if not accounts %}
+        <div class="text-center py-5">
+            <div class="card border-0 shadow-sm">
+                <div class="card-body py-5">
+                    <i class="bi bi-exclamation-triangle text-warning display-1 mb-3"></i>
+                    <h3 class="text-muted">No Accounts Detected</h3>
+                    <p class="text-muted">No Robinhood accounts were found. Please check your authentication.</p>
+                    <button class="btn btn-primary" onclick="window.location.reload()">
+                        <i class="bi bi-arrow-clockwise"></i> Refresh
+                    </button>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
+        <!-- Footer Info -->
+        <div class="text-center mt-5 py-4">
+            <div class="card border-0 bg-transparent">
+                <div class="card-body">
+                    <h6 class="text-muted mb-3">
+                        <i class="bi bi-info-circle"></i> How It Works
+                    </h6>
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <div class="text-primary mb-2">
+                                <i class="bi bi-search display-6"></i>
+                            </div>
+                            <h6>Auto-Detection</h6>
+                            <small class="text-muted">Automatically finds all your Robinhood accounts including Roth IRA, Traditional IRA, and standard accounts.</small>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <div class="text-success mb-2">
+                                <i class="bi bi-shield-shaded display-6"></i>
+                            </div>
+                            <h6>Isolated Processing</h6>
+                            <small class="text-muted">Each account runs independently to prevent cross-contamination of positions and orders.</small>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <div class="text-info mb-2">
+                                <i class="bi bi-graph-up display-6"></i>
+                            </div>
+                            <h6>Real-Time Monitoring</h6>
+                            <small class="text-muted">Independent trailing stop monitoring for each account during market hours.</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/risk_manager.html
+++ b/templates/risk_manager.html
@@ -84,15 +84,83 @@
             font-family: 'Courier New', monospace;
             font-size: 12px;
         }
+        
+        /* Trailing Stop Indicators */
+        .trail-stop-indicator {
+            font-size: 0.8rem;
+            font-weight: bold;
+            padding: 2px 6px;
+            border-radius: 12px;
+            margin-left: 8px;
+        }
+        .trail-stop-active {
+            background-color: #e3f2fd;
+            color: #1976d2;
+        }
+        .trail-stop-triggered {
+            background-color: #ffebee;
+            color: #c62828;
+            animation: pulse 1s infinite;
+        }
+        .trail-stop-submitted {
+            background-color: #fff3e0;
+            color: #ef6c00;
+        }
+        
+        /* Take Profit Indicators */
+        .take-profit-indicator {
+            font-size: 0.8rem;
+            font-weight: bold;
+            padding: 2px 6px;
+            border-radius: 12px;
+            margin-left: 8px;
+        }
+        .take-profit-active {
+            background-color: #e8f5e8;
+            color: #2e7d32;
+        }
+        .take-profit-triggered {
+            background-color: #e8f5e8;
+            color: #1b5e20;
+            animation: pulse 1s infinite;
+            box-shadow: 0 0 10px rgba(76, 175, 80, 0.5);
+        }
     </style>
 </head>
 <body>
     <div class="container-fluid mt-4">
         <h1 class="mb-4">
             📊 Options Risk Manager
+            {% if account_info %}
+            <span class="badge bg-info ms-2">{{ account_info.display_name }}</span>
+            {% endif %}
             <span id="marketStatus" class="badge bg-secondary ms-2">Market Closed</span>
             <span id="tradingMode" class="badge bg-warning ms-2">SIMULATION MODE</span>
         </h1>
+        
+        {% if account_info %}
+        <div class="row mb-3">
+            <div class="col">
+                <div class="card border-info">
+                    <div class="card-body py-2">
+                        <div class="row align-items-center">
+                            <div class="col-auto">
+                                <a href="/" class="btn btn-outline-secondary btn-sm">
+                                    <i class="bi bi-arrow-left"></i> Back to Accounts
+                                </a>
+                            </div>
+                            <div class="col">
+                                <small class="text-muted">
+                                    Monitoring: <strong>{{ account_info.display_name }}</strong>
+                                    - State: {{ account_info.state|title }}
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
         
         <div class="refresh-button">
             <button class="btn btn-primary me-2" onclick="loadPositions()">
@@ -169,7 +237,43 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                 </div>
                 <div class="modal-body">
-                    <p class="text-warning">⚠️ This will simulate placing the following sell orders (watch the Orders table above for status updates):</p>
+                    <!-- Quick Price Calculators -->
+                    <div class="mb-3">
+                        <h6>Quick Calculate:</h6>
+                        
+                        <!-- Stop Loss Slider -->
+                        <div class="mb-3">
+                            <div class="d-flex align-items-center">
+                                <button type="button" class="btn btn-outline-danger btn-sm me-2" onclick="calculateStopLoss()">
+                                    🛑 Stop Loss (-<span id="stopLossPercentDisplay">20</span>%)
+                                </button>
+                                <input type="range" class="form-range flex-grow-1 mx-2" id="stopLossSlider" 
+                                       min="5" max="50" value="20" step="1" 
+                                       onchange="updateStopLossButton()" oninput="updateStopLossPrice()">
+                                <small class="text-muted">5%-50%</small>
+                            </div>
+                        </div>
+                        
+                        <!-- Take Profit Slider -->
+                        <div class="mb-3">
+                            <div class="d-flex align-items-center">
+                                <button type="button" class="btn btn-outline-success btn-sm me-2" onclick="calculateTakeProfit()">
+                                    💰 Take Profit (+<span id="takeProfitPercentDisplay">50</span>%)
+                                </button>
+                                <input type="range" class="form-range flex-grow-1 mx-2" id="takeProfitSlider" 
+                                       min="10" max="200" value="50" step="5" 
+                                       onchange="updateTakeProfitButton()" oninput="updateTakeProfitPrice()">
+                                <small class="text-muted">10%-200%</small>
+                            </div>
+                        </div>
+                        
+                        <!-- Reset Button -->
+                        <button type="button" class="btn btn-outline-secondary btn-sm w-100" onclick="resetToDefault()">
+                            ↺ Reset to Default (Current Price - 5%)
+                        </button>
+                    </div>
+                    
+                    <p class="text-warning">⚠️ This will simulate placing the following sell orders:</p>
                     <div id="closeOrdersList"></div>
                     <div class="mt-3">
                         <strong>Total Estimated Proceeds: <span id="totalProceeds">$0.00</span></strong>
@@ -233,15 +337,64 @@
         </div>
     </div>
 
+    <!-- Take Profit Configuration Modal -->
+    <div class="modal fade" id="takeProfitModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">🎯 Take Profit Configuration</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <h6 id="takeProfitSymbol">Position: </h6>
+                        <small class="text-muted">Current P&L: <span id="takeProfitCurrentPnL">+0.0%</span></small>
+                    </div>
+                    
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="takeProfitEnabled">
+                        <label class="form-check-label" for="takeProfitEnabled">
+                            <strong>Enable Take Profit</strong>
+                        </label>
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="takeProfitPercent" class="form-label">Take Profit Percentage:</label>
+                        <input type="range" class="form-range" id="takeProfitPercent" min="10" max="200" value="50" step="5">
+                        <div class="d-flex justify-content-between">
+                            <small>10%</small>
+                            <strong><span id="takeProfitPercentDisplay">50</span>%</strong>
+                            <small>200%</small>
+                        </div>
+                    </div>
+                    
+                    <div class="alert alert-success">
+                        <strong>How it works:</strong><br>
+                        • Take profit will trigger when P&L reaches <strong>+<span id="takeProfitPercentInfo">50</span>%</span><br>
+                        • Current target: <strong>+<span id="takeProfitTargetDisplay">$0.00</span> profit</strong><br>
+                        • <strong>Automatic order placement</strong> when target is reached
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-success" onclick="saveTakeProfitConfig()">
+                        💾 Save Configuration
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         let positionsData = [];
         let selectedPositions = [];
+        const accountPrefix = {% if account_prefix %}'{{ account_prefix }}'{% else %}null{% endif %};
 
         function loadPositions() {
             document.getElementById('loadingIndicator').style.display = 'block';
             
-            fetch('/api/positions')
+            fetch(accountPrefix ? `/api/account/${accountPrefix}/positions` : '/api/positions')
                 .then(response => response.json())
                 .then(data => {
                     positionsData = data.positions;
@@ -312,6 +465,14 @@
                     trailStopIndicator = `<span class="trail-stop-indicator ${trailClass}">${trailText}</span>`;
                 }
                 
+                // Take profit indicator  
+                let takeProfitIndicator = '';
+                if (pos.take_profit && pos.take_profit.enabled) {
+                    const takeProfitClass = pos.take_profit.triggered ? 'take-profit-triggered' : 'take-profit-active';
+                    const takeProfitText = pos.take_profit.triggered ? '💰 TRIGGERED!' : `🎯 ${pos.take_profit.percent}%`;
+                    takeProfitIndicator = `<span class="take-profit-indicator ${takeProfitClass}">${takeProfitText}</span>`;
+                }
+                
                 html += `
                     <div class="card position-card">
                         <div class="card-header">
@@ -321,11 +482,15 @@
                                         <span class="status-indicator ${statusIcon}"></span>
                                         ${pos.symbol} ${pos.strike_price}${pos.option_type} ${pos.expiration_date}
                                         ${trailStopIndicator}
+                                        ${takeProfitIndicator}
                                     </h5>
                                 </div>
                                 <div class="col-auto">
                                     <button class="btn btn-outline-info btn-sm me-2" ${pos.trail_stop.order_submitted ? 'disabled' : ''} onclick="showTrailStopModal('${pos.symbol}', ${index})">
                                         🎯 Trail Stop
+                                    </button>
+                                    <button class="btn btn-outline-success btn-sm me-2" onclick="showTakeProfitModal('${pos.symbol}', ${index})">
+                                        💰 Take Profit
                                     </button>
                                     <button class="btn btn-outline-warning btn-sm" ${pos.trail_stop.order_submitted ? 'disabled title="Order already submitted via trailing stop"' : ''} onclick="showCloseModal([${index}])">
                                         📤 Close Position
@@ -442,7 +607,127 @@
             ordersList.innerHTML = html;
             totalProceeds.textContent = '$' + total.toFixed(2);
             
+            // Initialize calculated orders with default close_order data
+            window.calculatedOrders = positions.map(pos => ({
+                price: pos.close_order.price,
+                estimated_proceeds: pos.close_order.estimated_proceeds,
+                ...pos.close_order
+            }));
+            
             modal.show();
+            
+            // Show default prices with editable inputs
+            resetToDefault();
+        }
+        
+        function updateStopLossButton() {
+            const percent = document.getElementById('stopLossSlider').value;
+            document.getElementById('stopLossPercentDisplay').textContent = percent;
+        }
+        
+        function updateStopLossPrice() {
+            updateStopLossButton();
+            calculateStopLoss();
+        }
+        
+        function updateTakeProfitButton() {
+            const percent = document.getElementById('takeProfitSlider').value;
+            document.getElementById('takeProfitPercentDisplay').textContent = percent;
+        }
+        
+        function updateTakeProfitPrice() {
+            updateTakeProfitButton();
+            calculateTakeProfit();
+        }
+        
+        function calculateStopLoss() {
+            // Get current slider value
+            const percent = parseFloat(document.getElementById('stopLossSlider').value);
+            updateOrdersList(positions => positions.map(pos => {
+                const stopPrice = pos.current_price * (1 - percent / 100);
+                return {
+                    ...pos.close_order,
+                    price: stopPrice,
+                    estimated_proceeds: stopPrice * pos.quantity * 100
+                };
+            }));
+        }
+        
+        function calculateTakeProfit() {
+            // Get current slider value
+            const percent = parseFloat(document.getElementById('takeProfitSlider').value);
+            updateOrdersList(positions => positions.map(pos => {
+                const targetValue = pos.open_premium * (1 + percent / 100);
+                const limitPrice = targetValue / (pos.quantity * 100);
+                return {
+                    ...pos.close_order,
+                    price: limitPrice,
+                    estimated_proceeds: targetValue
+                };
+            }));
+        }
+        
+        function resetToDefault() {
+            // Reset to original default prices
+            updateOrdersList(positions => positions.map(pos => pos.close_order));
+        }
+        
+        function updateOrdersList(priceCalculator) {
+            const ordersList = document.getElementById('closeOrdersList');
+            const totalProceeds = document.getElementById('totalProceeds');
+            
+            let positions = selectedPositions.map(i => positionsData[i]);
+            let calculatedOrders = priceCalculator(positions);
+            let total = 0;
+            let html = '';
+            
+            positions.forEach((pos, i) => {
+                const order = calculatedOrders[i];
+                total += order.estimated_proceeds;
+                
+                html += `
+                    <div class="mb-3 p-2 border rounded">
+                        <strong>${pos.symbol} ${pos.strike_price}${pos.option_type}</strong><br>
+                        <div class="row align-items-center">
+                            <div class="col-auto">
+                                <label class="form-label mb-0">Limit Price:</label>
+                            </div>
+                            <div class="col">
+                                <input type="number" class="form-control form-control-sm" 
+                                       value="${order.price}" step="0.01" min="0" 
+                                       onchange="updateSingleOrder(${i}, this.value)">
+                            </div>
+                            <div class="col-auto">
+                                <small>→ $${order.estimated_proceeds.toFixed(2)}</small>
+                            </div>
+                        </div>
+                    </div>
+                `;
+            });
+            
+            ordersList.innerHTML = html;
+            totalProceeds.textContent = '$' + total.toFixed(2);
+            
+            // Store calculated orders for later use
+            window.calculatedOrders = calculatedOrders;
+        }
+        
+        function updateSingleOrder(positionIndex, newPrice) {
+            const pos = positionsData[selectedPositions[positionIndex]];
+            const newProceeds = parseFloat(newPrice) * pos.quantity * 100;
+            
+            // Update the stored order
+            window.calculatedOrders[positionIndex].price = parseFloat(newPrice);
+            window.calculatedOrders[positionIndex].estimated_proceeds = newProceeds;
+            
+            // Update display
+            const orderDiv = document.querySelectorAll('#closeOrdersList .border')[positionIndex];
+            const proceedsSpan = orderDiv.querySelector('small');
+            proceedsSpan.textContent = `→ $${newProceeds.toFixed(2)}`;
+            
+            // Update total
+            const total = window.calculatedOrders.reduce((sum, order) => sum + order.estimated_proceeds, 0);
+            document.getElementById('totalProceeds').textContent = '$' + total.toFixed(2);
         }
 
         function executeCloseSimulation() {
@@ -452,10 +737,28 @@
             submitButton.innerHTML = '⏳ Processing...';
             submitButton.disabled = true;
             
-            fetch('/api/close-simulation', {
+            // Get the positions with updated prices from the dialog
+            let ordersToSubmit = selectedPositions.map((positionIndex, i) => {
+                const originalPosition = positionsData[positionIndex];
+                
+                // Use calculated order price if available, otherwise use original
+                if (window.calculatedOrders && window.calculatedOrders[i]) {
+                    return {
+                        ...originalPosition,
+                        close_order: {
+                            ...originalPosition.close_order,
+                            price: window.calculatedOrders[i].price,
+                            estimated_proceeds: window.calculatedOrders[i].estimated_proceeds
+                        }
+                    };
+                }
+                return originalPosition;
+            });
+            
+            fetch(accountPrefix ? `/api/account/${accountPrefix}/close-simulation` : '/api/close-simulation', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({positions: selectedPositions})
+                body: JSON.stringify({positions: ordersToSubmit})
             })
             .then(response => response.json())
             .then(data => {
@@ -496,7 +799,7 @@
             const pollInterval = setInterval(() => {
                 pollCount++;
                 
-                fetch('/api/check-orders')
+                fetch(accountPrefix ? `/api/account/${accountPrefix}/check-orders` : '/api/check-orders')
                     .then(response => response.json())
                     .then(data => {
                         if (data.success && data.orders) {
@@ -560,7 +863,7 @@
             const enabled = document.getElementById('trailStopEnabled').checked;
             const percent = parseFloat(document.getElementById('trailStopPercent').value);
             
-            fetch('/api/trailing-stop', {
+            fetch(accountPrefix ? `/api/account/${accountPrefix}/trailing-stop` : '/api/trailing-stop', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
@@ -586,8 +889,74 @@
             });
         }
 
+        // Take Profit Modal Functions
+        let currentTakeProfitSymbol = '';
+        let currentTakeProfitPosition = null;
+
+        function showTakeProfitModal(symbol, positionIndex) {
+            const modal = new bootstrap.Modal(document.getElementById('takeProfitModal'));
+            currentTakeProfitSymbol = symbol;
+            currentTakeProfitPosition = positionsData[positionIndex];
+            
+            // Update modal content
+            document.getElementById('takeProfitSymbol').textContent = 
+                `Position: ${currentTakeProfitPosition.symbol} ${currentTakeProfitPosition.strike_price}${currentTakeProfitPosition.option_type}`;
+            document.getElementById('takeProfitCurrentPnL').textContent = 
+                `${currentTakeProfitPosition.pnl_percent >= 0 ? '+' : ''}${currentTakeProfitPosition.pnl_percent.toFixed(1)}%`;
+            
+            // Set current configuration (default to 50% if not set)
+            document.getElementById('takeProfitEnabled').checked = currentTakeProfitPosition.take_profit?.enabled || false;
+            document.getElementById('takeProfitPercent').value = currentTakeProfitPosition.take_profit?.percent || 50;
+            
+            updateTakeProfitPreview();
+            modal.show();
+        }
+
+        function updateTakeProfitPreview() {
+            const percent = parseFloat(document.getElementById('takeProfitPercent').value);
+            const openPremium = currentTakeProfitPosition.open_premium;
+            const targetValue = openPremium * (1 + percent / 100);
+            const targetProfit = targetValue - openPremium;
+            
+            document.getElementById('takeProfitPercentDisplay').textContent = percent;
+            document.getElementById('takeProfitPercentInfo').textContent = percent;
+            document.getElementById('takeProfitTargetDisplay').textContent = targetProfit.toFixed(2);
+        }
+
+        function saveTakeProfitConfig() {
+            const enabled = document.getElementById('takeProfitEnabled').checked;
+            const percent = parseFloat(document.getElementById('takeProfitPercent').value);
+            
+            fetch(accountPrefix ? `/api/account/${accountPrefix}/take-profit` : '/api/take-profit', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    symbol: currentTakeProfitSymbol,
+                    enabled: enabled,
+                    percent: percent
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert(`✅ Take profit configuration saved for ${currentTakeProfitSymbol}`);
+                    loadPositions(); // Refresh data
+                } else {
+                    alert('❌ Error: ' + data.error);
+                }
+                bootstrap.Modal.getInstance(document.getElementById('takeProfitModal')).hide();
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Error saving configuration');
+            });
+        }
+
+        // Update preview when slider changes
+        document.getElementById('takeProfitPercent').addEventListener('input', updateTakeProfitPreview);
+
         function checkOrderStatus() {
-            fetch('/api/check-orders')
+            fetch(accountPrefix ? `/api/account/${accountPrefix}/check-orders` : '/api/check-orders')
                 .then(response => response.json())
                 .then(data => {
                     if (data.success) {
@@ -673,7 +1042,7 @@
         document.getElementById('trailStopPercent').addEventListener('input', updateTrailStopPreview);
 
         function loadOrders() {
-            fetch('/api/check-orders')
+            fetch(accountPrefix ? `/api/account/${accountPrefix}/check-orders` : '/api/check-orders')
                 .then(response => response.json())
                 .then(data => {
                     renderOrdersTable(data);


### PR DESCRIPTION
- Add interactive sliders for stop loss (5-50%) and take profit (10-200%) in close position modal
- Implement real-time price calculation when moving sliders
- Fix simulated order submission to use custom prices from dialog instead of default calculations
- Add position matching logic to handle type differences (float vs int strike, case sensitivity)
- Update close order preview to show trailing stop orders when enabled
- Clean up debugging output and ensure both live and simulated orders use dialog prices

🤖 Generated with [Claude Code](https://claude.ai/code)