### PR TITLE
Add 'Reload Positions' endpoint/button and periodic reconcile\n\n- Ne…

### DIFF
--- a/templates/risk_manager.html
+++ b/templates/risk_manager.html
@@ -164,6 +164,7 @@
         
         <div class="refresh-button">
             <button class="btn btn-primary me-2" onclick="loadPositions()">Refresh</button>
+            <button class="btn btn-warning me-2" onclick="reloadPositions()">Reload Positions</button>
             <button class="btn btn-outline-info me-2" onclick="loadOrders()">Load Orders</button>
         </div>
 
@@ -400,6 +401,38 @@
                 })
                 .catch(error => {
                     console.error('Error loading positions:', error);
+                    document.getElementById('loadingIndicator').style.display = 'none';
+                });
+        }
+
+        function reloadPositions() {
+            if (!accountPrefix) {
+                alert('Please select an account first.');
+                return;
+            }
+            document.getElementById('loadingIndicator').style.display = 'block';
+            fetch(`/api/account/${accountPrefix}/reload-positions`, { method: 'POST' })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        console.log(data.message);
+                        // After reload, fetch fresh positions for display
+                        return fetch(`/api/account/${accountPrefix}/positions`)
+                            .then(r => r.json())
+                            .then(fresh => {
+                                positionsData = fresh.positions;
+                                updateSummary(fresh);
+                                renderPositions(fresh.positions);
+                            });
+                    } else {
+                        alert('Reload failed: ' + (data.error || 'Unknown error'));
+                    }
+                })
+                .catch(err => {
+                    console.error('Reload error:', err);
+                    alert('Error reloading positions');
+                })
+                .finally(() => {
                     document.getElementById('loadingIndicator').style.display = 'none';
                 });
         }


### PR DESCRIPTION
…w POST /api/account/<prefix>/reload-positions to force one-time refresh preserving trail_stop/take_profit\n- Added 'Reload Positions' UI button to account dashboard and handler\n- Periodic reconcile in monitoring loop (60s market hours, 300s off-hours)\n- Kept default Refresh behavior unchanged