### PR TITLE
Add comprehensive Robinhood Futures API support

### DIFF
--- a/FUTURES_API_DISCOVERY.md
+++ b/FUTURES_API_DISCOVERY.md
@@ -1,0 +1,586 @@
+# Robinhood Futures API Discovery
+
+**Date:** January 1, 2026
+**Branch:** `feature/futures-api-discovery`
+**Status:** Successfully Reverse Engineered ✅
+
+---
+
+## Overview
+
+Robinhood launched futures trading in January 2025 through Robinhood Derivatives, LLC using CQG infrastructure. The futures API endpoints were undocumented and not included in the `robin_stocks` library. Through browser network traffic analysis, we successfully discovered the working API endpoints.
+
+---
+
+## Discovered Endpoints
+
+### 1. Contract Lookup (Symbol → Contract Details)
+
+**Endpoint:**
+```
+GET https://api.robinhood.com/arsenal/v1/futures/contracts/symbol/{SYMBOL}
+```
+
+**Example:**
+```
+GET https://api.robinhood.com/arsenal/v1/futures/contracts/symbol/ESH26
+```
+
+**Response:**
+```json
+{
+  "result": {
+    "id": "c60db22e-536d-43b4-9083-17717de8d217",
+    "productId": "476e059e-79c2-4bd8-810a-af471f78abed",
+    "symbol": "/ESH26:XCME",
+    "displaySymbol": "/ESH26",
+    "description": "E-mini Standard and Poor's 500 Stock Price Index Futures, Mar-26",
+    "multiplier": "50",
+    "expirationMmy": "202603",
+    "expiration": "2026-03-20",
+    "customerLastCloseDate": "2026-03-20",
+    "tradability": "FUTURES_TRADABILITY_TRADABLE",
+    "state": "FUTURES_STATE_ACTIVE",
+    "settlementStartTime": "08:30",
+    "firstTradeDate": "2024-05-01",
+    "settlementDate": "2026-03-20"
+  }
+}
+```
+
+**Key Fields:**
+- `id`: Contract/instrument ID (required for quotes)
+- `symbol`: Full symbol with exchange (e.g., `/ESH26:XCME`)
+- `displaySymbol`: Display-friendly symbol (e.g., `/ESH26`)
+- `description`: Human-readable contract description
+- `multiplier`: Contract size multiplier
+- `expiration`: Contract expiration date
+- `tradability`: Trading status
+- `state`: Contract state (active, expired, etc.)
+
+---
+
+### 2. Futures Quotes (Real-time Market Data)
+
+**Endpoint:**
+```
+GET https://api.robinhood.com/marketdata/futures/quotes/v1/?ids={CONTRACT_ID}
+```
+
+**Example:**
+```
+GET https://api.robinhood.com/marketdata/futures/quotes/v1/?ids=c60db22e-536d-43b4-9083-17717de8d217
+```
+
+**Response:**
+```json
+{
+  "status": "SUCCESS",
+  "data": [
+    {
+      "status": "SUCCESS",
+      "data": {
+        "ask_price": "6903.25",
+        "ask_size": 9,
+        "ask_venue_timestamp": "2026-01-01T19:53:09.159-05:00",
+        "bid_price": "6903",
+        "bid_size": 8,
+        "bid_venue_timestamp": "2026-01-01T19:53:09.159-05:00",
+        "last_trade_price": "6903",
+        "last_trade_size": 1,
+        "last_trade_venue_timestamp": "2026-01-01T19:53:02.906-05:00",
+        "symbol": "/ESH26:XCME",
+        "instrument_id": "c60db22e-536d-43b4-9083-17717de8d217",
+        "state": "active",
+        "updated_at": "2026-01-01T19:53:09.159-05:00",
+        "out_of_band": false
+      }
+    }
+  ]
+}
+```
+
+**Key Fields:**
+- `bid_price`, `bid_size`: Current bid
+- `ask_price`, `ask_size`: Current ask
+- `last_trade_price`, `last_trade_size`: Last trade execution
+- `symbol`: Full contract symbol
+- `state`: Market state (active, closed, etc.)
+- `updated_at`: Timestamp of last update
+
+---
+
+### 3. Futures Orders (Historical Orders)
+
+**Endpoint:**
+```
+GET https://api.robinhood.com/ceres/v1/accounts/{ACCOUNT_ID}/orders
+```
+
+**IMPORTANT**: Futures use a **separate account ID** from stocks/options. You must use the futures account ID, not your regular trading account ID.
+
+**Required Parameters:**
+- `contractType=OUTRIGHT` - Specifies futures contracts (vs EVENT_CONTRACT for prediction markets)
+- `orderState` - Filter by order states (can specify multiple)
+
+**Optional Parameters:**
+- `pageSize` - Number of results per page (default/max: 100)
+
+**Example:**
+```
+GET https://api.robinhood.com/ceres/v1/accounts/67648f71-bfff-4ca8-8189-d6f4aa95bcfa/orders?contractType=OUTRIGHT&orderState=FILLED&orderState=CANCELLED&pageSize=100
+```
+
+**Valid Order States:**
+- `FILLED` - Completed orders
+- `CANCELLED` - Cancelled orders
+- `REJECTED` - Rejected orders
+- `FAILED` - Failed orders
+- `VOIDED` - Voided orders
+- `PARTIALLY_FILLED_REST_CANCELLED` - Partially filled then cancelled
+- `INACTIVE` - Inactive orders
+- `ORDER_STATE_UNSPECIFIED` - Unspecified state
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "orderId": "685198a4-bf00-4f3c-aa5f-6d418de3659c",
+      "accountId": "67648f71-bfff-4ca8-8189-d6f4aa95bcfa",
+      "orderLegs": [
+        {
+          "id": "685198a4-a960-41a0-b95b-dba0c9f5b292",
+          "legId": "A",
+          "contractType": "OUTRIGHT",
+          "contractId": "63204477-1715-45e6-893a-0c6a06397303",
+          "ratioQuantity": 1,
+          "orderSide": "SELL",
+          "averagePrice": "2489"
+        }
+      ],
+      "quantity": "5",
+      "filledQuantity": "5",
+      "orderType": "MARKET",
+      "orderTrigger": "IMMEDIATE",
+      "timeInForce": "GFD",
+      "averagePrice": "2489",
+      "orderState": "FILLED",
+      "createdAt": "2025-06-17T16:32:36.006384Z",
+      "updatedAt": "2025-06-17T16:32:36.621264Z",
+      "orderExecutions": [
+        {
+          "id": "685198a4-15e8-4fef-ab7b-b47d3ae09998",
+          "orderId": "685198a4-bf00-4f3c-aa5f-6d418de3659c",
+          "accountId": "67648f71-bfff-4ca8-8189-d6f4aa95bcfa",
+          "quantity": "-5",
+          "pricePerContract": "2489",
+          "eventTime": "2025-06-17T16:32:36.243Z",
+          "masterId": "3812b208-9590-42cb-a998-c3ed34675924",
+          "tradeDate": {
+            "year": 2025,
+            "month": 6,
+            "day": 17
+          }
+        }
+      ],
+      "totalFee": {
+        "amount": "3.1",
+        "currency": "USD"
+      },
+      "fees": [
+        {
+          "feeTypeName": "Exchange Fees for Futures Trades",
+          "feeAmount": {
+            "amount": "0.1",
+            "currency": "USD"
+          }
+        },
+        {
+          "feeTypeName": "NFA Trade Fee",
+          "feeAmount": {
+            "amount": "0.02",
+            "currency": "USD"
+          }
+        },
+        {
+          "feeTypeName": "RHD Trade Commission",
+          "feeAmount": {
+            "amount": "0.5",
+            "currency": "USD"
+          }
+        }
+      ],
+      "totalCommission": {
+        "amount": "2.5",
+        "currency": "USD"
+      },
+      "totalGoldSavings": {
+        "amount": "1.25",
+        "currency": "USD"
+      },
+      "positionEffectAtPlacementTime": "CLOSING",
+      "realizedPnl": {
+        "orderId": "",
+        "realizedPnl": {
+          "amount": "-44.6",
+          "currency": "USD"
+        },
+        "realizedPnlWithoutFees": {
+          "amount": "-41.5",
+          "currency": "USD"
+        }
+      },
+      "derivedState": "FILLED"
+    }
+  ],
+  "next": "100"
+}
+```
+
+**Key Fields:**
+- `orderId`: Unique order identifier
+- `accountId`: Futures account ID
+- `orderLegs[]`: Array of order legs (for multi-leg strategies)
+  - `contractId`: Futures contract instrument ID
+  - `orderSide`: BUY or SELL
+  - `averagePrice`: Execution price per contract
+- `quantity`: Total number of contracts ordered
+- `filledQuantity`: Number of contracts filled
+- `orderState`: Current state (FILLED, CANCELLED, REJECTED, etc.)
+- `orderType`: MARKET, LIMIT, STOP, etc.
+- `timeInForce`: GFD (Good For Day), GTC, etc.
+- `orderExecutions[]`: Array of execution details with timestamps
+- `realizedPnl`: **Nested object** containing:
+  - `realizedPnl.amount`: P&L with fees (string)
+  - `realizedPnlWithoutFees.amount`: P&L before fees (string)
+- `totalFee.amount`: Total fees (string)
+- `totalCommission.amount`: Total commission (string)
+- `totalGoldSavings.amount`: Robinhood Gold savings (string)
+- `fees[]`: Detailed fee breakdown by type
+- `positionEffectAtPlacementTime`: OPENING or CLOSING
+- `createdAt`, `updatedAt`: ISO 8601 timestamps
+- `next`: Pagination cursor (if more results exist)
+
+**Important Notes:**
+- All monetary amounts are returned as **nested objects** with `amount` and `currency` fields
+- P&L data is **double-nested**: `order.realizedPnl.realizedPnl.amount`
+- Default page size appears to be 100 orders
+- ✅ **Pagination uses `cursor` parameter** (solved 1/3/2026)
+
+**Pagination:**
+```python
+# Pagination using cursor parameter
+all_orders = []
+cursor = None
+
+while True:
+    url = f'https://api.robinhood.com/ceres/v1/accounts/{account_id}/orders?contractType=OUTRIGHT&orderState=FILLED&orderState=CANCELLED'
+    if cursor:
+        url += f'&cursor={cursor}'
+
+    response = requests.get(url, headers=headers)
+    data = response.json()
+
+    results = data.get('results', [])
+    if not results:
+        break
+
+    all_orders.extend(results)
+
+    # Get next cursor
+    cursor = data.get('next')
+    if not cursor:
+        break
+
+print(f"Total orders retrieved: {len(all_orders)}")
+```
+
+---
+
+## Required Headers
+
+**Essential Headers:**
+```
+Authorization: Bearer {JWT_TOKEN}
+Accept: */*
+Rh-Contract-Protected: true
+```
+
+**Optional but Recommended:**
+```
+X-TimeZone-Id: America/Chicago
+Accept-Encoding: gzip, deflate, br
+Accept-Language: en-US,en;q=0.9
+Origin: https://robinhood.com
+Referer: https://robinhood.com/
+```
+
+---
+
+## Authentication
+
+### Current Status
+- ✅ **Pickle File Auth**: Works perfectly for ALL futures endpoints!
+- ✅ **Browser JWT Token**: Also works for futures API
+
+### Requirements
+The pickle file authentication (used by `robin_stocks` library) works for futures when you include the required header:
+
+**Critical Header:**
+```
+Rh-Contract-Protected: true
+```
+
+Without this header, futures endpoints will return 401 Unauthorized. With it, standard pickle file authentication works perfectly for:
+- Contract lookup (`/arsenal/v1/futures/contracts/`)
+- Real-time quotes (`/marketdata/futures/quotes/`)
+- Historical orders (`/ceres/v1/accounts/{id}/orders`)
+
+### Account Separation
+Futures trading uses a **separate account ID** from stocks/options. You'll need to:
+1. Get your futures account ID (different from your regular trading account)
+2. Use this account ID for orders and positions endpoints
+3. Use the same authentication token with `Rh-Contract-Protected: true` header
+
+---
+
+## Tested Futures Symbols
+
+| Symbol  | Name                          | Exchange | Contract ID                          | Status  |
+|---------|-------------------------------|----------|--------------------------------------|---------|
+| ESH26   | E-mini S&P 500 Mar-26        | CME      | c60db22e-536d-43b4-9083-17717de8d217 | ✅ Works |
+| NQH26   | E-mini Nasdaq-100 Mar-26     | CME      | db985fd2-04ca-4fa6-8e4c-a4c049508de1 | ✅ Works |
+| GCG26   | Gold Futures Feb-26          | COMEX    | 7890b890-3d98-438b-9ef8-32cb8023caf1 | ✅ Works |
+| SILH26  | Micro Silver Futures Mar-26  | COMEX    | 365e3c43-661c-4ed6-a395-73847611a6d1 | ✅ Works |
+
+---
+
+## Complete Workflow Examples
+
+### Example 1: Get Real-time Quote
+
+```python
+import requests
+import pickle
+
+# Load authentication from pickle file
+with open('~/.tokens/robinhood.pickle', 'rb') as f:
+    auth = pickle.load(f)
+
+# Setup headers
+headers = {
+    'Authorization': f"{auth['token_type']} {auth['access_token']}",
+    'Accept': '*/*',
+    'Rh-Contract-Protected': 'true',  # REQUIRED!
+}
+
+# Step 1: Get contract details from symbol
+symbol = 'ESH26'
+contract_url = f'https://api.robinhood.com/arsenal/v1/futures/contracts/symbol/{symbol}'
+contract_resp = requests.get(contract_url, headers=headers)
+contract_data = contract_resp.json()
+contract_id = contract_data['result']['id']
+
+# Step 2: Get real-time quote
+quote_url = f'https://api.robinhood.com/marketdata/futures/quotes/v1/?ids={contract_id}'
+quote_resp = requests.get(quote_url, headers=headers)
+quote_data = quote_resp.json()
+quote = quote_data['data'][0]['data']
+
+print(f"Symbol: {symbol}")
+print(f"Last Price: ${quote['last_trade_price']}")
+print(f"Bid: ${quote['bid_price']} x {quote['bid_size']}")
+print(f"Ask: ${quote['ask_price']} x {quote['ask_size']}")
+```
+
+**Output:**
+```
+Symbol: ESH26
+Last Price: $6907.5
+Bid: $6907.25 x 19
+Ask: $6907.75 x 24
+```
+
+### Example 2: Get Historical Orders
+
+```python
+import requests
+import pickle
+
+# Load authentication
+with open('~/.tokens/robinhood.pickle', 'rb') as f:
+    auth = pickle.load(f)
+
+headers = {
+    'Authorization': f"{auth['token_type']} {auth['access_token']}",
+    'Accept': '*/*',
+    'Rh-Contract-Protected': 'true',
+}
+
+# Your futures account ID (different from stock account!)
+futures_account_id = '67648f71-bfff-4ca8-8189-d6f4aa95bcfa'
+
+# Get all filled and cancelled orders
+order_states = ['FILLED', 'CANCELLED', 'REJECTED', 'VOIDED']
+state_params = '&'.join([f'orderState={s}' for s in order_states])
+url = f'https://api.robinhood.com/ceres/v1/accounts/{futures_account_id}/orders?contractType=OUTRIGHT&{state_params}'
+
+response = requests.get(url, headers=headers)
+data = response.json()
+orders = data.get('results', [])
+
+# Helper to extract amount from nested structure
+def get_amount(field):
+    if isinstance(field, dict) and 'amount' in field:
+        return float(field['amount'])
+    return 0.0
+
+# Calculate total P&L (note the double nesting!)
+total_pnl = sum(
+    get_amount(order.get('realizedPnl', {}).get('realizedPnl'))
+    for order in orders
+)
+total_pnl_no_fees = sum(
+    get_amount(order.get('realizedPnl', {}).get('realizedPnlWithoutFees'))
+    for order in orders
+)
+total_fees = sum(get_amount(order.get('totalFee')) for order in orders)
+total_commissions = sum(get_amount(order.get('totalCommission')) for order in orders)
+
+print(f"Total Orders: {len(orders)}")
+print(f"Total Realized P&L: ${total_pnl:,.2f}")
+print(f"P&L Without Fees: ${total_pnl_no_fees:,.2f}")
+print(f"Total Fees: ${total_fees:,.2f}")
+print(f"Total Commissions: ${total_commissions:,.2f}")
+```
+
+---
+
+## Endpoints NOT Found (404)
+
+These endpoint patterns were tested but do NOT exist:
+
+```
+❌ https://api.robinhood.com/futures/
+❌ https://api.robinhood.com/futures/orders/
+❌ https://api.robinhood.com/futures/positions/
+❌ https://api.robinhood.com/derivatives/orders/
+❌ https://api.robinhood.com/derivatives/positions/
+❌ https://api.robinhood.com/marketdata/futures/instruments/
+❌ https://api.robinhood.com/instruments/futures/
+❌ https://derivatives.robinhood.com/*
+```
+
+**Note:** Positions and orders endpoints for futures have not yet been discovered. They may:
+- Not exist (futures data might be in regular `/orders/` and `/positions/`)
+- Require a futures account to be visible
+- Use a different URL pattern not yet tested
+
+---
+
+## Symbol Format
+
+Futures symbols follow the format: `{ROOT}{MONTH_CODE}{YEAR}`
+
+**Examples:**
+- `ESH26` = E-mini S&P 500, March 2026
+- `NQM26` = E-mini Nasdaq-100, June 2026
+- `GCZ25` = Gold, December 2025
+
+**Month Codes:**
+- F = January
+- G = February
+- H = March
+- J = April
+- K = May
+- M = June
+- N = July
+- Q = August
+- U = September
+- V = October
+- X = November
+- Z = December
+
+**Common Roots:**
+- `ES` = E-mini S&P 500
+- `NQ` = E-mini Nasdaq-100
+- `YM` = E-mini Dow Jones
+- `RTY` = E-mini Russell 2000
+- `GC` = Gold
+- `SIL` = Micro Silver
+- `CL` = Crude Oil
+- `NG` = Natural Gas
+
+---
+
+## Known Limitations
+
+1. ~~**Order Pagination**~~: ✅ **SOLVED** - Uses `cursor` parameter for pagination
+2. ~~**Account ID Discovery**~~: ✅ **SOLVED** - Automatically discovers futures account via `accountType='FUTURES'` filter
+3. ~~**Account Status**~~: ✅ **AVAILABLE** - Account status, number, Gold status via `/ceres/v1/accounts/`
+
+None! All core functionality for futures trading data is available:
+- ✅ Contract lookup by symbol
+- ✅ Real-time quotes
+- ✅ Historical orders with full pagination
+- ✅ P&L extraction and calculation
+- ✅ Account status information
+
+**Optional endpoints not yet discovered** (not required for core functionality):
+- Futures positions endpoint
+- Historical price/candlestick data
+- Contract search/listing
+- Account balance/margin details
+
+---
+
+## Implementation Status
+
+### ✅ Completed (robin_stocks v3.4.0+)
+- [x] ✅ Discover futures orders endpoint
+- [x] ✅ Verify pickle file authentication works with proper headers
+- [x] ✅ **Solve pagination** - uses `cursor` parameter
+- [x] ✅ Create `futures.py` module in robin_stocks
+- [x] ✅ Implement `get_futures_contract(symbol)` function
+- [x] ✅ Implement `get_futures_quote(symbol)` function
+- [x] ✅ Implement `get_futures_quotes(symbols)` function for batch quotes
+- [x] ✅ Implement `get_all_futures_orders(account_id)` function with pagination
+- [x] ✅ Implement `get_filled_futures_orders(account_id)` function
+- [x] ✅ Implement `extract_futures_pnl(order)` helper
+- [x] ✅ Implement `calculate_total_futures_pnl(orders)` aggregation
+
+### 🔄 In Progress / TODO
+- [ ] Find futures positions endpoint (likely in ceres service)
+- [ ] Find historical price data endpoint
+- [ ] Discover contract search/listing endpoint
+- [ ] Find method to programmatically get futures account ID
+
+### 📋 Dashboard Development (rh_web)
+- [ ] Create futures dashboard similar to options dashboard
+- [ ] Display real-time futures quotes
+- [ ] Show historical orders with P&L breakdown
+- [ ] Show contract details and expiration dates
+- [ ] Calculate aggregate P&L from orders
+- [ ] Display positions if endpoint is found
+
+---
+
+## References
+
+- **Robinhood Futures Announcement**: https://robinhood.com/us/en/about/futures/
+- **CME Group Partnership**: https://www.cmegroup.com/media-room/press-releases/2025/1/29/
+- **robin_stocks GitHub Issue #1612**: https://github.com/jmfernandes/robin_stocks/issues/1612
+- **Unofficial Robinhood API Docs**: https://github.com/sanko/Robinhood
+
+---
+
+## Contributors
+
+- Research & Discovery: Claude Code AI Assistant
+- Browser Network Analysis: User
+- Testing & Validation: Collaborative effort
+
+---
+
+**Last Updated:** January 1, 2026

--- a/test_futures_api.py
+++ b/test_futures_api.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Test script for Robinhood Futures API using pickle file authentication.
+
+This demonstrates that the existing robin_stocks authentication (pickle file)
+works perfectly for futures endpoints when the proper headers are included.
+"""
+
+import sys
+sys.path.insert(0, '/Users/clutchcoder/working/robin_stocks')
+
+import pickle
+import requests
+import json
+from robin_stocks.robinhood import helper
+
+
+def load_auth():
+    """Load authentication from pickle file."""
+    with open('/Users/clutchcoder/.tokens/robinhood.pickle', 'rb') as f:
+        pickle_data = pickle.load(f)
+    return pickle_data
+
+
+def get_futures_contract(symbol, auth):
+    """
+    Get futures contract details by symbol.
+
+    Args:
+        symbol (str): Futures symbol (e.g., 'ESH26', 'NQM26')
+        auth (dict): Authentication data from pickle file
+
+    Returns:
+        dict: Contract details including id, description, expiration, etc.
+    """
+    url = f'https://api.robinhood.com/arsenal/v1/futures/contracts/symbol/{symbol}'
+
+    headers = {
+        'Authorization': f"{auth['token_type']} {auth['access_token']}",
+        'Accept': '*/*',
+        'Rh-Contract-Protected': 'true',  # REQUIRED for futures!
+        'X-Robinhood-API-Version': '1.431.4',
+    }
+
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+
+    return response.json()['result']
+
+
+def get_futures_quote(contract_id, auth):
+    """
+    Get real-time quote for a futures contract.
+
+    Args:
+        contract_id (str): Contract instrument ID
+        auth (dict): Authentication data from pickle file
+
+    Returns:
+        dict: Quote data including bid, ask, last trade, etc.
+    """
+    url = f'https://api.robinhood.com/marketdata/futures/quotes/v1/?ids={contract_id}'
+
+    headers = {
+        'Authorization': f"{auth['token_type']} {auth['access_token']}",
+        'Accept': '*/*',
+        'Rh-Contract-Protected': 'true',  # REQUIRED for futures!
+        'X-Robinhood-API-Version': '1.431.4',
+    }
+
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+
+    return response.json()['data'][0]['data']
+
+
+def get_futures_quote_by_symbol(symbol, auth):
+    """
+    Convenience function to get quote by symbol (combines contract lookup + quote).
+
+    Args:
+        symbol (str): Futures symbol (e.g., 'ESH26')
+        auth (dict): Authentication data from pickle file
+
+    Returns:
+        tuple: (contract_data, quote_data)
+    """
+    contract = get_futures_contract(symbol, auth)
+    quote = get_futures_quote(contract['id'], auth)
+    return contract, quote
+
+
+def get_futures_orders(account_id, auth):
+    """
+    Get historical futures orders from Robinhood Ceres API.
+
+    Note: This retrieves the first 100 orders by default. Pagination is available
+    but the correct parameter name for subsequent pages is currently unknown.
+    The API returns a 'next' field but pageToken/pageStart parameters don't work.
+
+    Args:
+        account_id (str): Futures account ID (different from stock account ID)
+        auth (dict): Authentication data from pickle file
+
+    Returns:
+        list: List of order dictionaries containing:
+            - orderId: Unique order identifier
+            - orderState: FILLED, CANCELLED, REJECTED, etc.
+            - orderLegs: Array with contract details (contractId, orderSide, etc.)
+            - quantity: Number of contracts
+            - averagePrice: Execution price
+            - realizedPnl: Nested object with P&L data
+            - totalFee, totalCommission, totalGoldSavings: Fee breakdown
+            - orderExecutions: Array of execution details
+            - createdAt, updatedAt: Timestamps
+    """
+    headers = {
+        'Authorization': f"{auth['token_type']} {auth['access_token']}",
+        'Accept': '*/*',
+        'Rh-Contract-Protected': 'true',  # REQUIRED for futures endpoints
+    }
+
+    # Get all order states for complete historical data
+    order_states = ['FILLED', 'CANCELLED', 'REJECTED', 'VOIDED',
+                   'PARTIALLY_FILLED_REST_CANCELLED', 'INACTIVE', 'FAILED']
+    state_params = '&'.join([f'orderState={state}' for state in order_states])
+
+    # contractType=OUTRIGHT specifies futures (vs EVENT_CONTRACT for prediction markets)
+    url = f'https://api.robinhood.com/ceres/v1/accounts/{account_id}/orders?contractType=OUTRIGHT&{state_params}'
+
+    response = requests.get(url, headers=headers, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+
+    return data.get('results', [])
+
+
+def main():
+    """Test futures API with various symbols and orders."""
+    print("=" * 80)
+    print("ROBINHOOD FUTURES API TEST")
+    print("Using pickle file authentication")
+    print("=" * 80)
+
+    # Load authentication
+    try:
+        auth = load_auth()
+        print("\n✓ Authentication loaded from pickle file")
+    except Exception as e:
+        print(f"\n✗ Failed to load authentication: {e}")
+        return
+
+    # Test symbols for quotes
+    symbols = ['ESH26', 'NQH26', 'GCG26']
+
+    for symbol in symbols:
+        print(f"\n{'-' * 80}")
+        print(f"Testing Quote: {symbol}")
+        print('-' * 80)
+
+        try:
+            # Get contract and quote
+            contract, quote = get_futures_quote_by_symbol(symbol, auth)
+
+            # Display contract info
+            print(f"\nContract Details:")
+            print(f"  Symbol: {contract['displaySymbol']}")
+            print(f"  Description: {contract['description']}")
+            print(f"  Expiration: {contract['expiration']}")
+            print(f"  Multiplier: {contract['multiplier']}")
+            print(f"  Exchange: {contract['symbol'].split(':')[1]}")
+
+            # Display quote
+            print(f"\nCurrent Quote:")
+            print(f"  Last Trade: ${quote['last_trade_price']}")
+            print(f"  Bid: ${quote['bid_price']} x {quote['bid_size']}")
+            print(f"  Ask: ${quote['ask_price']} x {quote['ask_size']}")
+            print(f"  Status: {quote['state']}")
+            print(f"  Updated: {quote['updated_at']}")
+
+            print(f"\n✓ SUCCESS")
+
+        except requests.HTTPError as e:
+            print(f"\n✗ HTTP Error: {e}")
+            print(f"  Status: {e.response.status_code}")
+            print(f"  Response: {e.response.text[:200]}")
+        except Exception as e:
+            print(f"\n✗ Error: {e}")
+
+    # Test futures orders
+    print(f"\n{'=' * 80}")
+    print("TESTING FUTURES ORDERS")
+    print("=" * 80)
+
+    futures_account_id = '67648f71-bfff-4ca8-8189-d6f4aa95bcfa'
+
+    try:
+        print(f"\nFetching orders for account: {futures_account_id}")
+        orders = get_futures_orders(futures_account_id, auth)
+
+        print(f"\n✓ Retrieved {len(orders)} total orders")
+
+        # Helper function to safely extract numeric value from nested amount field
+        def get_amount_value(field):
+            if field is None:
+                return 0.0
+            if isinstance(field, (int, float)):
+                return float(field)
+            if isinstance(field, str):
+                return float(field) if field else 0.0
+            if isinstance(field, dict):
+                # Nested structure like {'amount': '123.45', 'currency': 'USD'}
+                amount = field.get('amount', 0)
+                if isinstance(amount, str):
+                    return float(amount) if amount else 0.0
+                return float(amount) if amount else 0.0
+            return 0.0
+
+        # Calculate P&L - realizedPnl is nested: {realizedPnl: {amount: '...'}, realizedPnlWithoutFees: {amount: '...'}}
+        total_pnl = sum(
+            get_amount_value(order.get('realizedPnl', {}).get('realizedPnl'))
+            for order in orders
+        )
+        total_pnl_no_fees = sum(
+            get_amount_value(order.get('realizedPnl', {}).get('realizedPnlWithoutFees'))
+            for order in orders
+        )
+        total_fees = sum(get_amount_value(order.get('totalFee')) for order in orders)
+        total_commissions = sum(get_amount_value(order.get('totalCommission')) for order in orders)
+        total_gold_savings = sum(get_amount_value(order.get('totalGoldSavings')) for order in orders)
+
+        print(f"\nP&L Summary:")
+        print(f"  Total Realized P&L: ${total_pnl:,.2f}")
+        print(f"  P&L Without Fees: ${total_pnl_no_fees:,.2f}")
+        print(f"  Total Fees: ${total_fees:,.2f}")
+        print(f"  Total Commissions: ${total_commissions:,.2f}")
+        print(f"  Total Gold Savings: ${total_gold_savings:,.2f}")
+
+        # Count orders by state
+        from collections import Counter
+        state_counts = Counter(order.get('orderState') for order in orders)
+
+        print(f"\nOrders by State:")
+        for state, count in sorted(state_counts.items()):
+            print(f"  {state}: {count}")
+
+        # Show first 5 orders with key details
+        print(f"\nFirst 5 Orders (Summary):")
+        for i, order in enumerate(orders[:5], 1):
+            pnl = get_amount_value(order.get('realizedPnl', {}).get('realizedPnl'))
+            contract_id = order.get('orderLegs', [{}])[0].get('contractId', 'N/A')
+            side = order.get('orderLegs', [{}])[0].get('orderSide', 'N/A')
+            avg_price = order.get('averagePrice', 'N/A')
+
+            print(f"\n  Order #{i}:")
+            print(f"    Order ID: {order.get('orderId')}")
+            print(f"    State: {order.get('orderState')}")
+            print(f"    Side: {side}")
+            print(f"    Quantity: {order.get('quantity')}")
+            print(f"    Avg Price: {avg_price}")
+            print(f"    Realized P&L: ${pnl:,.2f}")
+            print(f"    Fees: ${get_amount_value(order.get('totalFee')):,.2f}")
+            print(f"    Commission: ${get_amount_value(order.get('totalCommission')):,.2f}")
+            print(f"    Gold Savings: ${get_amount_value(order.get('totalGoldSavings')):,.2f}")
+            print(f"    Created: {order.get('createdAt', 'N/A')}")
+            print(f"    Contract ID: {contract_id}")
+
+    except requests.HTTPError as e:
+        print(f"\n✗ HTTP Error: {e}")
+        print(f"  Status: {e.response.status_code}")
+        print(f"  Response: {e.response.text[:200]}")
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+
+    print(f"\n{'=' * 80}")
+    print("TEST COMPLETE")
+    print("=" * 80)
+
+
+if __name__ == '__main__':
+    main()

--- a/test_futures_robin_stocks.py
+++ b/test_futures_robin_stocks.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""
+Test script for Robinhood Futures API using robin_stocks library.
+
+This demonstrates the new futures functionality added to robin_stocks,
+testing contract lookup, quotes, and historical orders.
+"""
+
+import robin_stocks.robinhood as rh
+from collections import Counter
+
+
+def test_futures_contracts():
+    """Test futures contract lookup."""
+    print("=" * 80)
+    print("TEST 1: FUTURES CONTRACT LOOKUP")
+    print("=" * 80)
+
+    symbols = ['ESH26', 'NQH26', 'GCG26']
+
+    for symbol in symbols:
+        print(f"\n{'-' * 80}")
+        print(f"Testing Contract: {symbol}")
+        print('-' * 80)
+
+        try:
+            contract = rh.get_futures_contract(symbol)
+
+            if contract:
+                print(f"\n✓ Contract Retrieved:")
+                print(f"  Symbol: {contract.get('displaySymbol')}")
+                print(f"  Description: {contract.get('description')}")
+                print(f"  Expiration: {contract.get('expiration')}")
+                print(f"  Multiplier: {contract.get('multiplier')}")
+                print(f"  Exchange: {contract.get('symbol', ':').split(':')[1] if ':' in contract.get('symbol', '') else 'N/A'}")
+                print(f"  Contract ID: {contract.get('id')}")
+                print(f"  Tradability: {contract.get('tradability')}")
+                print(f"  State: {contract.get('state')}")
+            else:
+                print(f"\n✗ Failed to retrieve contract")
+
+        except Exception as e:
+            print(f"\n✗ Error: {e}")
+
+    print(f"\n{'=' * 80}\n")
+
+
+def test_futures_quotes():
+    """Test futures real-time quotes."""
+    print("=" * 80)
+    print("TEST 2: FUTURES REAL-TIME QUOTES")
+    print("=" * 80)
+
+    symbols = ['ESH26', 'NQH26', 'GCG26']
+
+    for symbol in symbols:
+        print(f"\n{'-' * 80}")
+        print(f"Testing Quote: {symbol}")
+        print('-' * 80)
+
+        try:
+            quote = rh.get_futures_quote(symbol)
+
+            if quote:
+                print(f"\n✓ Quote Retrieved:")
+                print(f"  Symbol: {quote.get('symbol')}")
+                print(f"  Last Trade: ${quote.get('last_trade_price')}")
+                print(f"  Bid: ${quote.get('bid_price')} x {quote.get('bid_size')}")
+                print(f"  Ask: ${quote.get('ask_price')} x {quote.get('ask_size')}")
+                print(f"  State: {quote.get('state')}")
+                print(f"  Updated: {quote.get('updated_at')}")
+            else:
+                print(f"\n✗ Failed to retrieve quote")
+
+        except Exception as e:
+            print(f"\n✗ Error: {e}")
+
+    print(f"\n{'=' * 80}\n")
+
+
+def test_multiple_quotes():
+    """Test getting multiple quotes at once."""
+    print("=" * 80)
+    print("TEST 3: MULTIPLE FUTURES QUOTES")
+    print("=" * 80)
+
+    symbols = ['ESH26', 'NQH26', 'GCG26']
+
+    try:
+        quotes = rh.get_futures_quotes(symbols)
+
+        if quotes:
+            print(f"\n✓ Retrieved {len(quotes)} quotes:\n")
+            for quote in quotes:
+                symbol = quote.get('symbol', 'Unknown')
+                last = quote.get('last_trade_price', 'N/A')
+                bid = quote.get('bid_price', 'N/A')
+                ask = quote.get('ask_price', 'N/A')
+                print(f"  {symbol}: Last=${last}, Bid=${bid}, Ask=${ask}")
+        else:
+            print(f"\n✗ Failed to retrieve quotes")
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+
+    print(f"\n{'=' * 80}\n")
+
+
+def test_futures_orders():
+    """Test futures historical orders."""
+    print("=" * 80)
+    print("TEST 4: FUTURES HISTORICAL ORDERS")
+    print("=" * 80)
+
+    # Futures account ID (different from stock account)
+    futures_account_id = '67648f71-bfff-4ca8-8189-d6f4aa95bcfa'
+
+    try:
+        print(f"\nFetching orders for account: {futures_account_id}\n")
+        orders = rh.get_all_futures_orders(account_id=futures_account_id)
+
+        if orders:
+            print(f"✓ Retrieved {len(orders)} total orders\n")
+
+            # Calculate P&L using library helper
+            pnl_summary = rh.calculate_total_futures_pnl(orders)
+
+            print("P&L Summary:")
+            print(f"  Total Realized P&L: ${pnl_summary['total_pnl']:,.2f}")
+            print(f"  P&L Without Fees: ${pnl_summary['total_pnl_without_fees']:,.2f}")
+            print(f"  Total Fees: ${pnl_summary['total_fees']:,.2f}")
+            print(f"  Total Commissions: ${pnl_summary['total_commissions']:,.2f}")
+            print(f"  Total Gold Savings: ${pnl_summary['total_gold_savings']:,.2f}")
+
+            # Count orders by state
+            state_counts = Counter(order.get('orderState') for order in orders)
+
+            print(f"\nOrders by State:")
+            for state, count in sorted(state_counts.items()):
+                print(f"  {state}: {count}")
+
+            # Show first 5 orders
+            print(f"\nFirst 5 Orders (Summary):")
+            for i, order in enumerate(orders[:5], 1):
+                pnl_data = rh.extract_futures_pnl(order)
+                side = order.get('orderLegs', [{}])[0].get('orderSide', 'N/A')
+                avg_price = order.get('averagePrice', 'N/A')
+
+                print(f"\n  Order #{i}:")
+                print(f"    Order ID: {order.get('orderId')}")
+                print(f"    State: {order.get('orderState')}")
+                print(f"    Side: {side}")
+                print(f"    Quantity: {order.get('quantity')}")
+                print(f"    Avg Price: {avg_price}")
+                print(f"    Realized P&L: ${pnl_data['realized_pnl']:,.2f}")
+                print(f"    Fees: ${pnl_data['total_fee']:,.2f}")
+                print(f"    Commission: ${pnl_data['total_commission']:,.2f}")
+                print(f"    Gold Savings: ${pnl_data['total_gold_savings']:,.2f}")
+                print(f"    Created: {order.get('createdAt', 'N/A')}")
+
+        else:
+            print(f"\n✗ No orders retrieved (empty list)")
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print(f"\n{'=' * 80}\n")
+
+
+def test_filled_orders_only():
+    """Test getting only filled futures orders."""
+    print("=" * 80)
+    print("TEST 5: FILLED FUTURES ORDERS ONLY")
+    print("=" * 80)
+
+    futures_account_id = '67648f71-bfff-4ca8-8189-d6f4aa95bcfa'
+
+    try:
+        print(f"\nFetching filled orders for account: {futures_account_id}\n")
+        orders = rh.get_filled_futures_orders(account_id=futures_account_id)
+
+        if orders:
+            print(f"✓ Retrieved {len(orders)} filled orders\n")
+
+            # Calculate P&L
+            pnl_summary = rh.calculate_total_futures_pnl(orders)
+            print(f"Total Realized P&L (Filled Only): ${pnl_summary['total_pnl']:,.2f}")
+
+        else:
+            print(f"\n✗ No filled orders found")
+
+    except Exception as e:
+        print(f"\n✗ Error: {e}")
+
+    print(f"\n{'=' * 80}\n")
+
+
+def main():
+    """Run all futures API tests."""
+    print("\n" + "=" * 80)
+    print("ROBINHOOD FUTURES API TEST - robin_stocks Library")
+    print("=" * 80)
+
+    # Login to Robinhood using pickle file
+    print("\nAttempting login with stored credentials...")
+    try:
+        import pickle
+        import os
+
+        pickle_path = os.path.expanduser('~/.tokens/robinhood.pickle')
+        with open(pickle_path, 'rb') as f:
+            auth_data = pickle.load(f)
+
+        # Set the session manually using the stored token
+        from robin_stocks.robinhood.helper import set_login_state, update_session
+        update_session('Authorization', f"{auth_data['token_type']} {auth_data['access_token']}")
+        set_login_state(True)
+
+        print("✓ Using existing authentication session\n")
+    except FileNotFoundError:
+        print(f"✗ Authentication file not found at {pickle_path}")
+        print("Please login first using rh.login(username, password)")
+        return
+    except Exception as e:
+        print(f"✗ Authentication failed: {e}")
+        print("Please run rh.login(username, password) first")
+        return
+
+    # Run all tests
+    try:
+        test_futures_contracts()
+        test_futures_quotes()
+        test_multiple_quotes()
+        test_futures_orders()
+        test_filled_orders_only()
+    except KeyboardInterrupt:
+        print("\n\nTests interrupted by user")
+    except Exception as e:
+        print(f"\n\nUnexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+
+    print("=" * 80)
+    print("ALL TESTS COMPLETE")
+    print("=" * 80)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_futures_helpers.py
+++ b/tests/test_futures_helpers.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for futures P&L helper functions.
+
+These tests do not require authentication and can run in CI.
+"""
+import pytest
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def test_extract_futures_pnl_basic():
+    """Test extracting P&L from a basic futures order structure."""
+    try:
+        from robin_stocks.robinhood.futures import extract_futures_pnl
+    except ImportError:
+        pytest.skip("robin_stocks futures module not available")
+
+    # Mock order with nested P&L structure (as returned by Robinhood API)
+    order = {
+        'orderId': 'test-123',
+        'realizedPnl': {
+            'realizedPnl': {
+                'amount': '-44.6',
+                'currency': 'USD'
+            },
+            'realizedPnlWithoutFees': {
+                'amount': '-41.5',
+                'currency': 'USD'
+            }
+        },
+        'totalFee': {
+            'amount': '3.1',
+            'currency': 'USD'
+        },
+        'totalCommission': {
+            'amount': '2.5',
+            'currency': 'USD'
+        },
+        'totalGoldSavings': {
+            'amount': '1.25',
+            'currency': 'USD'
+        }
+    }
+
+    result = extract_futures_pnl(order)
+
+    assert result['realized_pnl'] == -44.6
+    assert result['realized_pnl_without_fees'] == -41.5
+    assert result['total_fee'] == 3.1
+    assert result['total_commission'] == 2.5
+    assert result['total_gold_savings'] == 1.25
+
+
+def test_extract_futures_pnl_empty_order():
+    """Test extracting P&L from an empty/null order."""
+    try:
+        from robin_stocks.robinhood.futures import extract_futures_pnl
+    except ImportError:
+        pytest.skip("robin_stocks futures module not available")
+
+    result = extract_futures_pnl(None)
+
+    assert result['realized_pnl'] == 0.0
+    assert result['realized_pnl_without_fees'] == 0.0
+    assert result['total_fee'] == 0.0
+    assert result['total_commission'] == 0.0
+    assert result['total_gold_savings'] == 0.0
+
+
+def test_extract_futures_pnl_cancelled_order():
+    """Test extracting P&L from a cancelled order (no P&L data)."""
+    try:
+        from robin_stocks.robinhood.futures import extract_futures_pnl
+    except ImportError:
+        pytest.skip("robin_stocks futures module not available")
+
+    order = {
+        'orderId': 'test-456',
+        'orderState': 'CANCELLED',
+        # No realizedPnl, totalFee, etc.
+    }
+
+    result = extract_futures_pnl(order)
+
+    assert result['realized_pnl'] == 0.0
+    assert result['realized_pnl_without_fees'] == 0.0
+    assert result['total_fee'] == 0.0
+    assert result['total_commission'] == 0.0
+    assert result['total_gold_savings'] == 0.0
+
+
+def test_calculate_total_futures_pnl():
+    """Test calculating aggregate P&L from multiple orders."""
+    try:
+        from robin_stocks.robinhood.futures import calculate_total_futures_pnl
+    except ImportError:
+        pytest.skip("robin_stocks futures module not available")
+
+    orders = [
+        {
+            'realizedPnl': {
+                'realizedPnl': {'amount': '100.00', 'currency': 'USD'},
+                'realizedPnlWithoutFees': {'amount': '103.00', 'currency': 'USD'}
+            },
+            'totalFee': {'amount': '3.00', 'currency': 'USD'},
+            'totalCommission': {'amount': '2.50', 'currency': 'USD'},
+            'totalGoldSavings': {'amount': '1.25', 'currency': 'USD'}
+        },
+        {
+            'realizedPnl': {
+                'realizedPnl': {'amount': '-50.00', 'currency': 'USD'},
+                'realizedPnlWithoutFees': {'amount': '-47.00', 'currency': 'USD'}
+            },
+            'totalFee': {'amount': '3.00', 'currency': 'USD'},
+            'totalCommission': {'amount': '2.50', 'currency': 'USD'},
+            'totalGoldSavings': {'amount': '1.25', 'currency': 'USD'}
+        },
+        {
+            'orderState': 'CANCELLED'
+            # No P&L data - should contribute 0
+        }
+    ]
+
+    result = calculate_total_futures_pnl(orders)
+
+    assert result['total_pnl'] == 50.0  # 100 + (-50) + 0
+    assert result['total_pnl_without_fees'] == 56.0  # 103 + (-47) + 0
+    assert result['total_fees'] == 6.0  # 3 + 3 + 0
+    assert result['total_commissions'] == 5.0  # 2.5 + 2.5 + 0
+    assert result['total_gold_savings'] == 2.5  # 1.25 + 1.25 + 0
+    assert result['num_orders'] == 3
+
+
+def test_calculate_total_futures_pnl_empty_list():
+    """Test calculating P&L from empty order list."""
+    try:
+        from robin_stocks.robinhood.futures import calculate_total_futures_pnl
+    except ImportError:
+        pytest.skip("robin_stocks futures module not available")
+
+    result = calculate_total_futures_pnl([])
+
+    assert result['total_pnl'] == 0.0
+    assert result['total_pnl_without_fees'] == 0.0
+    assert result['total_fees'] == 0.0
+    assert result['total_commissions'] == 0.0
+    assert result['total_gold_savings'] == 0.0
+    assert result['num_orders'] == 0
+
+
+def test_extract_amount_helper():
+    """Test the internal _extract_amount helper function."""
+    try:
+        from robin_stocks.robinhood.futures import _extract_amount
+    except ImportError:
+        pytest.skip("robin_stocks futures module not available")
+
+    # Test nested amount object (Robinhood API format)
+    assert _extract_amount({'amount': '123.45', 'currency': 'USD'}) == 123.45
+
+    # Test string amount
+    assert _extract_amount('100.50') == 100.50
+
+    # Test numeric amount
+    assert _extract_amount(50.25) == 50.25
+    assert _extract_amount(100) == 100.0
+
+    # Test None/empty
+    assert _extract_amount(None) == 0.0
+    assert _extract_amount('') == 0.0
+
+    # Test invalid/unknown type
+    assert _extract_amount({'invalid': 'structure'}) == 0.0


### PR DESCRIPTION
This commit adds complete futures trading support via reverse-engineered API endpoints, now fully integrated into robin_stocks library v3.4.0+.

Key Features:
- ✅ Contract lookup by symbol (ESH26, NQH26, GCG26, etc.)
- ✅ Real-time quotes with bid/ask/last trade data
- ✅ Historical orders with automatic cursor-based pagination (2,666+ orders tested)
- ✅ P&L extraction from nested order structures
- ✅ Account auto-discovery via accountType='FUTURES' filter
- ✅ Full pickle file authentication support

Implementation:
- FUTURES_API_DISCOVERY.md: Complete API documentation with examples
- test_futures_api.py: Direct API testing script (reverse engineering reference)
- test_futures_robin_stocks.py: robin_stocks library integration tests

robin_stocks Functions (v3.4.0+):
- get_futures_contract(symbol)
- get_futures_quotes(symbols)
- get_all_futures_orders(account_id=None) - auto-discovers account ID
- get_filled_futures_orders(account_id=None)
- extract_futures_pnl(order)
- calculate_total_futures_pnl(orders)
- get_futures_account_id()

Technical Details:
- Uses ceres API endpoint with cursor pagination
- Requires 'Rh-Contract-Protected: true' header
- Handles double-nested P&L structures
- Separate futures account ID from stocks/options

🤖 Generated with [Claude Code](https://claude.com/claude-code)