### PR TITLE
Apply partial fills fix to production futures module

### DIFF
--- a/futures/data_fetcher.py
+++ b/futures/data_fetcher.py
@@ -169,8 +169,13 @@ class FuturesDataFetcher:
             print(f"Found {len(all_orders)} total futures orders from API")
 
             # Filter for filled orders to store in database
-            filled_orders = [order for order in all_orders if order.get('orderState') == 'FILLED']
-            print(f"Found {len(filled_orders)} filled orders")
+            # Include both FILLED and PARTIALLY_FILLED_REST_CANCELLED (partial fills are real executions)
+            filled_orders = [
+                order for order in all_orders
+                if order.get('orderState') in ['FILLED', 'PARTIALLY_FILLED_REST_CANCELLED']
+                and int(order.get('filledQuantity', 0)) > 0
+            ]
+            print(f"Found {len(filled_orders)} filled orders (including partial fills)")
 
             # Get last order date from database to see if we have new orders
             last_order_date = self.db.get_last_order_date()

--- a/futures/futures_web.py
+++ b/futures/futures_web.py
@@ -167,6 +167,25 @@ def get_positions_by_date(date):
             'error': f'Failed to fetch orders for date {date}'
         }), 500
 
+@app.route('/api/daily-summary/<date>')
+def get_daily_summary(date):
+    """Get daily trading summary (Purchase and Sale Summary format)"""
+    try:
+        summary = data_fetcher.db.get_daily_summary(date)
+
+        return jsonify({
+            'success': True,
+            'summary': summary
+        })
+
+    except Exception as e:
+        print(f"Daily Summary API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': f'Failed to fetch summary for date {date}'
+        }), 500
+
 
 if __name__ == '__main__':
     # Start server and check if database needs initial setup


### PR DESCRIPTION
Updates all queries and data fetching to include PARTIALLY_FILLED_REST_CANCELLED orders. Adds daily summary (Purchase and Sale Summary format) to calendar view.

Changes:
- data_fetcher.py: Include partial fills when fetching from Robinhood
- database.py: Update all queries, add get_daily_summary() method
- futures_web.py: Add /api/daily-summary/<date> endpoint
- calendar.js: Display Purchase and Sale Summary in day modal

This completes the partial fills fix implementation across the entire module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)