### PR TITLE
Add stocks dashboard with comprehensive P&L tracking and analytics

### DIFF
--- a/stocks/data_fetcher.py
+++ b/stocks/data_fetcher.py
@@ -1,0 +1,274 @@
+import robin_stocks.robinhood as r
+import datetime
+import traceback
+from typing import Dict, List, Optional
+from stocks.database import StocksDatabase
+
+class StocksDataFetcher:
+    def __init__(self, db_path: str = "stocks.db"):
+        self.db = StocksDatabase(db_path)
+
+    def login_robinhood(self, username: str = None, password: str = None) -> bool:
+        """Login to Robinhood"""
+        try:
+            # Try to login with saved credentials first
+            r.login()
+            return True
+        except Exception as e:
+            # If login fails, prompt for credentials
+            if not username or not password:
+                import getpass
+                print("Robinhood login required:")
+                username = input("Enter your username: ")
+                password = getpass.getpass("Enter your password: ")
+
+            try:
+                r.login(username, password)
+                return True
+            except Exception as login_error:
+                print(f"Login failed: {str(login_error)}")
+                return False
+
+    def fetch_stock_orders(self) -> Dict:
+        """Fetch stock orders from Robinhood"""
+        try:
+            print("Fetching stock orders from Robinhood...")
+
+            # Get all stock orders
+            all_orders = r.get_all_stock_orders()
+
+            if not isinstance(all_orders, list):
+                raise ValueError(f"Expected list of orders, got {type(all_orders)}")
+
+            print(f"Found {len(all_orders)} total stock orders from API")
+
+            # Filter for filled orders only
+            filled_orders = [
+                order for order in all_orders
+                if order.get('state') == 'filled'
+                and float(order.get('cumulative_quantity', 0)) > 0
+            ]
+            print(f"Found {len(filled_orders)} filled orders")
+
+            # First, collect all unique instrument IDs and fetch their symbols
+            print("Fetching instrument symbols...")
+            instrument_ids = list(set(order.get('instrument_id') for order in filled_orders if order.get('instrument_id')))
+            print(f"Found {len(instrument_ids)} unique instruments")
+
+            # Build cache of instrument_id -> symbol
+            instrument_cache = {}
+            for i, inst_id in enumerate(instrument_ids):
+                try:
+                    url = f'https://api.robinhood.com/instruments/{inst_id}/'
+                    instrument = r.get_instrument_by_url(url)
+                    instrument_cache[inst_id] = instrument.get('symbol', 'UNKNOWN')
+
+                    if (i + 1) % 10 == 0:
+                        print(f"  Fetched {i + 1}/{len(instrument_ids)} symbols...")
+                except Exception as e:
+                    print(f"  Error fetching instrument {inst_id}: {e}")
+                    instrument_cache[inst_id] = 'UNKNOWN'
+
+            print(f"Fetched all {len(instrument_cache)} symbols")
+
+            # Now process all orders using the cache
+            print("Processing orders...")
+            processed_orders = []
+            for order in filled_orders:
+                try:
+                    # Get symbol from cache
+                    instrument_id = order.get('instrument_id')
+                    symbol = instrument_cache.get(instrument_id, 'UNKNOWN')
+
+                    # Get trade date from execution, with fallback to last_transaction_at
+                    trade_date = None
+
+                    # Try to get from executions first (more accurate)
+                    executions = order.get('executions', [])
+                    if executions and executions[0].get('trade_execution_date'):
+                        trade_date = executions[0].get('trade_execution_date')
+
+                    # Fallback to extracting from last_transaction_at
+                    if not trade_date:
+                        last_transaction = order.get('last_transaction_at', '')
+                        trade_date = last_transaction.split('T')[0] if last_transaction else None
+
+                    processed_orders.append({
+                        'order_id': order.get('id'),
+                        'symbol': symbol,
+                        'side': order.get('side'),  # 'buy' or 'sell'
+                        'quantity': float(order.get('cumulative_quantity', 0)),
+                        'average_price': float(order.get('average_price', 0)),
+                        'total_amount': float(order.get('executed_notional', {}).get('amount', 0)),
+                        'fees': float(order.get('fees', 0)),
+                        'state': order.get('state'),
+                        'created_at': order.get('created_at'),
+                        'last_transaction_at': order.get('last_transaction_at'),
+                        'trade_date': trade_date,
+                        'raw_data': order
+                    })
+                except Exception as e:
+                    print(f"Error processing order {order.get('id')}: {e}")
+                    continue
+
+            print(f"Processed all {len(processed_orders)} orders")
+
+            # Insert into database
+            inserted_count = self.db.insert_orders(processed_orders)
+            print(f"Inserted {inserted_count} new orders (duplicates skipped)")
+
+            return {
+                'success': True,
+                'orders_fetched': len(all_orders),
+                'orders_inserted': inserted_count,
+                'message': f"Successfully updated database with {inserted_count} new orders"
+            }
+
+        except Exception as e:
+            print(f"Error fetching stock orders: {str(e)}")
+            print(traceback.format_exc())
+            return {
+                'success': False,
+                'error': 'Failed to fetch stock orders from Robinhood',
+                'traceback': traceback.format_exc()
+            }
+
+    def get_open_positions(self) -> List[Dict]:
+        """Get current open positions from Robinhood"""
+        try:
+            open_positions = r.get_open_stock_positions()
+
+            if not open_positions:
+                return []
+
+            # Get current quotes for unrealized P&L
+            positions_with_pnl = []
+            for pos in open_positions:
+                symbol = pos.get('symbol')
+                quantity = float(pos.get('quantity', 0))
+                avg_buy_price = float(pos.get('average_buy_price', 0))
+
+                # Get current price
+                try:
+                    quote = r.get_stock_quote_by_symbol(symbol)
+                    current_price = float(quote.get('last_trade_price', 0))
+                except:
+                    current_price = 0
+
+                cost_basis = quantity * avg_buy_price
+                market_value = quantity * current_price
+                unrealized_pnl = market_value - cost_basis
+
+                positions_with_pnl.append({
+                    'symbol': symbol,
+                    'quantity': quantity,
+                    'average_buy_price': avg_buy_price,
+                    'current_price': current_price,
+                    'cost_basis': round(cost_basis, 2),
+                    'market_value': round(market_value, 2),
+                    'unrealized_pnl': round(unrealized_pnl, 2),
+                    'created_at': pos.get('created_at'),
+                    'updated_at': pos.get('updated_at')
+                })
+
+            return positions_with_pnl
+
+        except Exception as e:
+            print(f"Error getting open positions: {str(e)}")
+            return []
+
+    def get_processed_data(self, include_open_positions: bool = True) -> Dict:
+        """Get processed data from database"""
+        try:
+            # Get all orders
+            all_orders = self.db.get_all_orders()
+
+            # Get open positions from Robinhood (only if logged in)
+            open_positions = []
+            if include_open_positions:
+                try:
+                    open_positions = self.get_open_positions()
+                except Exception as e:
+                    print(f"Could not fetch open positions (may not be logged in): {e}")
+                    open_positions = []
+
+            # Calculate P&L summary from CLOSED POSITIONS (FIFO matched)
+            closed_positions = self.db.get_closed_positions()
+            total_pnl = sum(pos['pnl'] for pos in closed_positions)
+
+            # Calculate win rate
+            winning_trades = sum(1 for pos in closed_positions if pos['pnl'] > 0)
+            losing_trades = sum(1 for pos in closed_positions if pos['pnl'] < 0)
+            breakeven_trades = sum(1 for pos in closed_positions if pos['pnl'] == 0)
+            total_closed = len(closed_positions)
+            win_rate = (winning_trades / total_closed * 100) if total_closed > 0 else 0
+
+            # Also get daily breakdown and fees
+            daily_pnl = self.db.get_daily_pnl()
+            total_fees = sum(day['fees'] for day in daily_pnl.values())
+
+            # Get total trading days (all days with any orders, not just closed positions)
+            all_trading_dates = self.db.get_all_trading_dates()
+            num_trading_days = len(all_trading_dates)
+
+            # Calculate total possible trading days since first trade
+            if all_trading_dates:
+                from datetime import datetime
+                first_trade_date = datetime.strptime(all_trading_dates[0], '%Y-%m-%d')
+                last_trade_date = datetime.strptime(all_trading_dates[-1], '%Y-%m-%d')
+                years_trading = (last_trade_date - first_trade_date).days / 365.25
+                approx_market_days = int(years_trading * 252)  # ~252 trading days per year
+            else:
+                approx_market_days = 0
+
+            # Calculate unrealized P&L from open positions
+            total_unrealized_pnl = sum(pos['unrealized_pnl'] for pos in open_positions)
+
+            pnl_summary = {
+                'total_pnl': round(total_pnl, 2),
+                'total_unrealized_pnl': round(total_unrealized_pnl, 2),
+                'total_fees': round(total_fees, 2),
+                'num_orders': len(all_orders),
+                'num_open_positions': len(open_positions),
+                'num_trading_days': num_trading_days,
+                'approx_market_days': approx_market_days,
+                'total_closed_positions': total_closed,
+                'winning_trades': winning_trades,
+                'losing_trades': losing_trades,
+                'win_rate': round(win_rate, 1)
+            }
+
+            print(f"P&L Summary: Total=${pnl_summary['total_pnl']:.2f}, Unrealized=${pnl_summary['total_unrealized_pnl']:.2f}, Orders={pnl_summary['num_orders']}, Days={num_trading_days}")
+
+            return {
+                'all_orders': all_orders,
+                'open_positions': open_positions,
+                'summary': pnl_summary
+            }
+
+        except Exception as e:
+            print(f"Error getting processed data: {str(e)}")
+            print(traceback.format_exc())
+            return {
+                'error': True,
+                'message': 'Failed to retrieve processed data from database',
+                'traceback': traceback.format_exc()
+            }
+
+    def update_data(self, username: str = None, password: str = None) -> Dict:
+        """Update the database with latest data"""
+        # Login first
+        if not self.login_robinhood(username, password):
+            return {
+                'success': False,
+                'error': 'Failed to login to Robinhood'
+            }
+
+        # Fetch and process data
+        fetch_result = self.fetch_stock_orders()
+
+        if fetch_result['success']:
+            # Return processed data
+            return self.get_processed_data()
+        else:
+            return fetch_result

--- a/stocks/database.py
+++ b/stocks/database.py
@@ -1,0 +1,408 @@
+import sqlite3
+import json
+import datetime
+from typing import Dict, List, Optional
+
+class StocksDatabase:
+    def __init__(self, db_path: str = "stocks.db"):
+        self.db_path = db_path
+        self.init_database()
+
+    def init_database(self):
+        """Initialize the SQLite database with required tables"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        # Create stock_orders table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS stock_orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_id TEXT UNIQUE,
+                symbol TEXT,
+                side TEXT,
+                quantity REAL,
+                average_price REAL,
+                total_amount REAL,
+                fees REAL DEFAULT 0,
+                state TEXT,
+                created_at TEXT,
+                last_transaction_at TEXT,
+                trade_date TEXT,
+                raw_data TEXT,
+                fetched_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+
+        # Create indexes
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_order_id ON stock_orders(order_id)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_symbol ON stock_orders(symbol)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_trade_date ON stock_orders(trade_date)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_state ON stock_orders(state)')
+
+        conn.commit()
+        conn.close()
+
+    def get_last_order_date(self) -> Optional[str]:
+        """Get the date of the most recent order in the database"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute('SELECT MAX(created_at) FROM stock_orders')
+        result = cursor.fetchone()
+
+        conn.close()
+        return result[0] if result and result[0] else None
+
+    def insert_orders(self, orders: List[Dict]) -> int:
+        """Insert new orders into the database, returning count of inserted orders"""
+        if not orders:
+            return 0
+
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        inserted_count = 0
+        for order in orders:
+            try:
+                cursor.execute('''
+                    INSERT OR IGNORE INTO stock_orders (
+                        order_id, symbol, side, quantity, average_price,
+                        total_amount, fees, state, created_at, last_transaction_at,
+                        trade_date, raw_data
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    order.get('order_id'),
+                    order.get('symbol'),
+                    order.get('side'),
+                    float(order.get('quantity', 0)),
+                    float(order.get('average_price', 0)),
+                    float(order.get('total_amount', 0)),
+                    float(order.get('fees', 0)),
+                    order.get('state'),
+                    order.get('created_at'),
+                    order.get('last_transaction_at'),
+                    order.get('trade_date'),
+                    json.dumps(order.get('raw_data', {}))
+                ))
+                if cursor.rowcount > 0:
+                    inserted_count += 1
+            except Exception as e:
+                print(f"Error inserting order {order.get('order_id')}: {e}")
+
+        conn.commit()
+        conn.close()
+        return inserted_count
+
+    def get_all_orders(self) -> List[Dict]:
+        """Get all orders from database"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute('''
+            SELECT order_id, symbol, side, quantity, average_price,
+                   total_amount, fees, state, created_at, last_transaction_at, trade_date
+            FROM stock_orders
+            WHERE state = 'filled'
+            ORDER BY last_transaction_at DESC
+        ''')
+
+        orders = []
+        for row in cursor.fetchall():
+            orders.append({
+                'order_id': row[0],
+                'symbol': row[1],
+                'side': row[2],
+                'quantity': row[3],
+                'average_price': row[4],
+                'total_amount': row[5],
+                'fees': row[6],
+                'state': row[7],
+                'created_at': row[8],
+                'last_transaction_at': row[9],
+                'trade_date': row[10]
+            })
+
+        conn.close()
+        return orders
+
+    def get_closed_positions(self) -> List[Dict]:
+        """
+        Get all closed positions with FIFO P&L calculation.
+        Returns list of closed position pairs.
+        """
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        # Get all orders by symbol
+        cursor.execute('''
+            SELECT symbol, side, quantity, total_amount, average_price, trade_date, last_transaction_at
+            FROM stock_orders
+            WHERE state = 'filled'
+            ORDER BY symbol, last_transaction_at
+        ''')
+
+        # Group by symbol
+        from collections import defaultdict
+        symbol_orders = defaultdict(list)
+
+        for row in cursor.fetchall():
+            symbol, side, qty, total, avg_price, date, timestamp = row
+            symbol_orders[symbol].append({
+                'side': side,
+                'quantity': float(qty or 0),
+                'total_amount': float(total or 0),
+                'average_price': float(avg_price or 0),
+                'trade_date': date,
+                'timestamp': timestamp
+            })
+
+        conn.close()
+
+        # Calculate closed positions using FIFO
+        closed_positions = []
+
+        for symbol, orders in symbol_orders.items():
+            buy_queue = []  # FIFO queue of buys
+
+            for order in orders:
+                if order['side'] == 'buy':
+                    # Add to buy queue
+                    buy_queue.append({
+                        'quantity': order['quantity'],
+                        'price': order['average_price'],
+                        'cost': order['total_amount'],
+                        'date': order['trade_date']
+                    })
+                else:  # sell
+                    sell_qty = order['quantity']
+                    sell_proceeds = order['total_amount']
+                    sell_price = order['average_price']
+                    sell_date = order['trade_date']
+
+                    # Match against buy queue (FIFO)
+                    while sell_qty > 0 and buy_queue:
+                        buy = buy_queue[0]
+
+                        matched_qty = min(buy['quantity'], sell_qty)
+                        portion = matched_qty / order['quantity']
+                        matched_proceeds = sell_proceeds * portion
+                        matched_cost = (matched_qty / buy['quantity']) * buy['cost']
+
+                        # Create closed position record
+                        closed_positions.append({
+                            'symbol': symbol,
+                            'quantity': matched_qty,
+                            'buy_price': buy['price'],
+                            'sell_price': sell_price,
+                            'buy_date': buy['date'],
+                            'sell_date': sell_date,
+                            'cost': round(matched_cost, 2),
+                            'proceeds': round(matched_proceeds, 2),
+                            'pnl': round(matched_proceeds - matched_cost, 2)
+                        })
+
+                        if buy['quantity'] <= sell_qty:
+                            # Fully use this buy
+                            sell_qty -= buy['quantity']
+                            buy_queue.pop(0)
+                        else:
+                            # Partially use this buy
+                            buy['quantity'] -= sell_qty
+                            buy['cost'] -= matched_cost
+                            sell_qty = 0
+
+        return closed_positions
+
+    def get_total_realized_pnl(self) -> float:
+        """Get total realized P&L from closed positions"""
+        closed = self.get_closed_positions()
+        return sum(pos['pnl'] for pos in closed)
+
+    def get_daily_pnl(self, start_date=None, end_date=None) -> Dict:
+        """
+        Get daily realized P&L summary.
+        Only counts P&L from properly FIFO-matched closed positions.
+        P&L is attributed to the sell date.
+        """
+        # Get all closed positions (FIFO matched)
+        closed_positions = self.get_closed_positions()
+
+        # Group by sell_date
+        daily_pnl = {}
+        for pos in closed_positions:
+            sell_date = pos['sell_date']
+
+            # Apply date filters if provided
+            if start_date and sell_date < start_date:
+                continue
+            if end_date and sell_date > end_date:
+                continue
+
+            if sell_date not in daily_pnl:
+                daily_pnl[sell_date] = {
+                    'pnl': 0,
+                    'fees': 0,
+                    'pnl_no_fees': 0,
+                    'count': 0
+                }
+
+            daily_pnl[sell_date]['pnl'] += pos['pnl']
+            daily_pnl[sell_date]['count'] += 1
+
+        # Round all values
+        for date in daily_pnl:
+            daily_pnl[date]['pnl'] = round(daily_pnl[date]['pnl'], 2)
+            daily_pnl[date]['pnl_no_fees'] = round(daily_pnl[date]['pnl'], 2)  # stocks have no fees
+
+        return daily_pnl
+
+    def get_all_trading_dates(self) -> List[str]:
+        """Get all unique trading dates with activity"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute('''
+            SELECT DISTINCT trade_date
+            FROM stock_orders
+            WHERE state = 'filled' AND trade_date IS NOT NULL
+            ORDER BY trade_date
+        ''')
+
+        dates = [row[0] for row in cursor.fetchall()]
+
+        conn.close()
+        return dates
+
+    def get_orders_by_trade_date(self, trade_date: str) -> List[Dict]:
+        """Get all orders for a specific trade date"""
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute('''
+            SELECT order_id, symbol, side, quantity, average_price,
+                   total_amount, fees, last_transaction_at
+            FROM stock_orders
+            WHERE trade_date = ? AND state = 'filled'
+            ORDER BY last_transaction_at
+        ''', (trade_date,))
+
+        orders = []
+        for row in cursor.fetchall():
+            orders.append({
+                'order_id': row[0],
+                'symbol': row[1],
+                'side': row[2],
+                'quantity': row[3],
+                'average_price': row[4],
+                'total_amount': row[5],
+                'fees': row[6],
+                'execution_time': row[7]
+            })
+
+        conn.close()
+        return orders
+
+    def get_daily_summary(self, trade_date: str) -> Dict:
+        """
+        Get daily summary showing both opened and closed positions for this date.
+        Closed positions show buy/sell prices with P&L.
+        Opened positions show buy price only (no P&L since not closed yet).
+        """
+        from collections import defaultdict
+
+        # Get all closed positions that were sold on this date
+        closed_positions = self.get_closed_positions()
+
+        # Group closed positions by symbol
+        closed_data = defaultdict(lambda: {
+            'total_quantity': 0,
+            'total_cost': 0,
+            'total_proceeds': 0,
+            'total_pnl': 0,
+            'positions_count': 0
+        })
+
+        for pos in closed_positions:
+            if pos['sell_date'] == trade_date:
+                symbol = pos['symbol']
+                closed_data[symbol]['total_quantity'] += pos['quantity']
+                closed_data[symbol]['total_cost'] += pos['cost']
+                closed_data[symbol]['total_proceeds'] += pos['proceeds']
+                closed_data[symbol]['total_pnl'] += pos['pnl']
+                closed_data[symbol]['positions_count'] += 1
+
+        # Build closed positions list
+        closed_symbols = []
+        total_closed_quantity = 0
+        total_pnl = 0
+
+        for symbol in sorted(closed_data.keys()):
+            data = closed_data[symbol]
+            quantity = data['total_quantity']
+            avg_buy_price = data['total_cost'] / quantity if quantity > 0 else 0
+            avg_sell_price = data['total_proceeds'] / quantity if quantity > 0 else 0
+
+            closed_symbols.append({
+                'symbol': symbol,
+                'quantity': quantity,
+                'avg_buy_price': round(avg_buy_price, 2),
+                'avg_sell_price': round(avg_sell_price, 2),
+                'pnl': round(data['total_pnl'], 2)
+            })
+
+            total_closed_quantity += quantity
+            total_pnl += data['total_pnl']
+
+        # Get opened positions (buy orders on this date that weren't immediately sold)
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute('''
+            SELECT symbol, quantity, average_price
+            FROM stock_orders
+            WHERE trade_date = ? AND state = 'filled' AND side = 'buy'
+            ORDER BY symbol
+        ''', (trade_date,))
+
+        # Group opened positions by symbol
+        opened_data = defaultdict(lambda: {
+            'total_quantity': 0,
+            'total_cost': 0
+        })
+
+        for row in cursor.fetchall():
+            symbol, quantity, avg_price = row
+            opened_data[symbol]['total_quantity'] += float(quantity or 0)
+            opened_data[symbol]['total_cost'] += float(quantity or 0) * float(avg_price or 0)
+
+        conn.close()
+
+        # Build opened positions list
+        opened_symbols = []
+        total_opened_quantity = 0
+
+        for symbol in sorted(opened_data.keys()):
+            data = opened_data[symbol]
+            quantity = data['total_quantity']
+            avg_buy_price = data['total_cost'] / quantity if quantity > 0 else 0
+
+            opened_symbols.append({
+                'symbol': symbol,
+                'quantity': quantity,
+                'avg_buy_price': round(avg_buy_price, 2)
+            })
+
+            total_opened_quantity += quantity
+
+        return {
+            'date': trade_date,
+            'closed_positions': closed_symbols,
+            'opened_positions': opened_symbols,
+            'totals': {
+                'positions_closed': len(closed_symbols),
+                'positions_opened': len(opened_symbols),
+                'total_closed_quantity': total_closed_quantity,
+                'total_opened_quantity': total_opened_quantity,
+                'total_pnl': round(total_pnl, 2)
+            }
+        }

--- a/stocks/static/css/styles.css
+++ b/stocks/static/css/styles.css
@@ -1,0 +1,547 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f7f7f7;
+    color: #333;
+}
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+header {
+    background-color: #00C805;
+    color: white;
+    padding: 15px 0;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+h1, h2, h3 {
+    margin: 0;
+    text-align: center;
+}
+h1 {
+    font-size: 28px;
+}
+h2 {
+    font-size: 22px;
+    margin-top: 20px;
+    margin-bottom: 15px;
+    color: #333;
+    border-bottom: 2px solid #00C805;
+    padding-bottom: 10px;
+}
+.tab-container {
+    margin-top: 20px;
+}
+.tabs {
+    display: flex;
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 20px;
+}
+.tab {
+    padding: 10px 20px;
+    cursor: pointer;
+    background-color: #f1f1f1;
+    border: 1px solid #ddd;
+    border-bottom: none;
+    margin-right: 5px;
+    border-radius: 5px 5px 0 0;
+    transition: all 0.3s ease;
+}
+.tab:hover {
+    background-color: #e9e9e9;
+}
+.tab.active {
+    background-color: #00C805;
+    color: white;
+    border-color: #00C805;
+}
+.tab-content {
+    display: none;
+}
+.tab-content.active {
+    display: block;
+}
+.filters {
+    margin-bottom: 20px;
+    padding: 15px;
+    background: white;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+.filter-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-bottom: 10px;
+}
+select, input {
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    flex-grow: 1;
+    min-width: 120px;
+}
+button {
+    background-color: #00C805;
+    color: white;
+    border: none;
+    padding: 8px 15px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+button:hover {
+    background-color: #00A804;
+}
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: white;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    border-radius: 5px;
+    overflow: hidden;
+    margin-bottom: 20px;
+}
+th, td {
+    padding: 12px 15px;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+}
+th {
+    background-color: #00C805;
+    color: white;
+    position: sticky;
+    top: 0;
+    cursor: pointer;
+}
+th:hover {
+    background-color: #00A804;
+}
+th.sort-asc::after {
+    content: " ▲";
+}
+th.sort-desc::after {
+    content: " ▼";
+}
+tr:hover {
+    background-color: #f9f9f9;
+}
+.buy, .debit {
+    color: #FF5000;
+    font-weight: bold;
+}
+.sell, .credit {
+    color: #00C805;
+    font-weight: bold;
+}
+.loading {
+    text-align: center;
+    padding: 40px;
+    font-size: 18px;
+    color: #666;
+}
+.error {
+    background-color: #ffeeee;
+    color: #cc0000;
+    padding: 15px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+    text-align: center;
+}
+.summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+.summary-card {
+    background: white;
+    padding: 15px;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    flex: 1;
+    min-width: 200px;
+    text-align: center;
+}
+.summary-card h3 {
+    margin-bottom: 10px;
+    color: #555;
+}
+.summary-card .value {
+    font-size: 24px;
+    font-weight: bold;
+    color: #333;
+}
+.profit {
+    color: #00C805;
+}
+.loss {
+    color: #FF5000;
+}
+.empty-message {
+    text-align: center;
+    padding: 30px;
+    color: #666;
+    font-style: italic;
+}
+
+/* Added styles for date filters */
+.date-range {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+.date-range label {
+    white-space: nowrap;
+}
+
+/* Calendar Styles */
+.calendar-container {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    padding: 20px;
+}
+
+.pnl-event {
+    text-align: center;
+    font-weight: bold;
+}
+
+.pnl-amount {
+    font-size: 12px;
+    line-height: 1.1;
+}
+
+.pnl-count {
+    font-size: 9px;
+    opacity: 0.8;
+    line-height: 1;
+}
+
+/* Modal Styles */
+.modal {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: white;
+    margin: 5% auto;
+    padding: 0;
+    border: none;
+    width: 90%;
+    max-width: 800px;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+    animation: modalFadeIn 0.3s;
+}
+
+@keyframes modalFadeIn {
+    from { opacity: 0; transform: scale(0.9); }
+    to { opacity: 1; transform: scale(1); }
+}
+
+.modal-header {
+    background-color: #00C805;
+    color: white;
+    padding: 15px 20px;
+    border-radius: 8px 8px 0 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.modal-header h3 {
+    margin: 0;
+    text-align: left;
+}
+
+.close {
+    color: white;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.close:hover,
+.close:focus {
+    color: #ccc;
+}
+
+.modal-body {
+    padding: 20px;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.position-details-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+.position-details-table th {
+    background-color: #f8f9fa;
+    padding: 12px 8px;
+    text-align: left;
+    border-bottom: 2px solid #dee2e6;
+    font-weight: 600;
+    color: #495057;
+    font-size: 12px;
+}
+
+.position-details-table td {
+    padding: 10px 8px;
+    border-bottom: 1px solid #dee2e6;
+    font-size: 12px;
+}
+
+.position-details-table tr:hover {
+    background-color: #f8f9fa;
+}
+
+.profit {
+    color: #28a745;
+    font-weight: 600;
+}
+
+.loss {
+    color: #dc3545;
+    font-weight: 600;
+}
+
+/* FullCalendar customizations */
+.fc-event {
+    border-radius: 3px !important;
+    border: none !important;
+    font-weight: bold !important;
+}
+
+.fc-event-title {
+    font-weight: bold;
+}
+
+.fc-daygrid-event {
+    margin: 1px 2px !important;
+}
+
+/* Responsive Calendar */
+@media (max-width: 768px) {
+    .filter-row {
+        flex-direction: column;
+        gap: 10px;
+    }
+    .date-range {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    table {
+        font-size: 14px;
+    }
+    th, td {
+        padding: 8px 10px;
+    }
+    
+    .modal-content {
+        width: 95%;
+        margin: 10% auto;
+    }
+    
+    .position-details-table {
+        font-size: 11px;
+    }
+    
+    .position-details-table th,
+    .position-details-table td {
+        padding: 8px 4px;
+    }
+    
+    .pnl-amount {
+        font-size: 10px;
+    }
+    
+    .pnl-count {
+        font-size: 8px;
+    }
+}
+
+/* Modular Component Styles */
+
+/* Message system */
+.message {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    padding: 12px 20px;
+    border-radius: 4px;
+    color: white;
+    font-weight: 500;
+    z-index: 1000;
+    max-width: 300px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    animation: slideIn 0.3s ease-out;
+}
+
+.message-success {
+    background-color: #28a745;
+}
+
+.message-error {
+    background-color: #dc3545;
+}
+
+.message-info {
+    background-color: #007bff;
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+/* Loading states */
+.loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.loading-spinner {
+    width: 40px;
+    height: 40px;
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #007bff;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+/* Enhanced table styles for components */
+.table-container {
+    overflow-x: auto;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background: white;
+}
+
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.data-table th {
+    background-color: #f8f9fa;
+    padding: 12px 8px;
+    text-align: left;
+    font-weight: 600;
+    border-bottom: 2px solid #e9ecef;
+    position: relative;
+    user-select: none;
+}
+
+.data-table th.sortable {
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.data-table th.sortable:hover {
+    background-color: #e9ecef;
+}
+
+.data-table td {
+    padding: 10px 8px;
+    border-bottom: 1px solid #f1f1f1;
+    transition: background-color 0.2s;
+}
+
+.data-table tbody tr:hover {
+    background-color: #f8f9fa;
+}
+
+/* No data state */
+.no-data {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6c757d;
+    font-style: italic;
+    background: white;
+    border-radius: 8px;
+}
+/* Heatmap Styles */
+.heatmap-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 10px;
+    background: #f9f9f9;
+    border-radius: 8px;
+}
+
+.heatmap-box {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    cursor: pointer;
+    transition: transform 0.2s;
+    padding: 8px;
+    overflow: hidden;
+    text-align: center;
+}
+
+.heatmap-box:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+}
+
+.heatmap-symbol {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.heatmap-pnl {
+    font-size: 1.4em;
+    font-weight: bold;
+    margin-bottom: 3px;
+}
+
+.heatmap-trades {
+    font-size: 0.8em;
+    opacity: 0.9;
+}
+
+.heatmap-winrate {
+    font-size: 0.8em;
+    opacity: 0.9;
+}

--- a/stocks/static/js/calendar.js
+++ b/stocks/static/js/calendar.js
@@ -1,0 +1,464 @@
+// Calendar View Manager for Daily P&L Display
+class CalendarManager {
+    constructor() {
+        this.calendar = null;
+        this.dailyPnlData = {};
+    }
+
+    async initCalendar() {
+        const calendarEl = document.getElementById('calendarView');
+        
+        if (!calendarEl) {
+            console.error('Calendar element not found');
+            return;
+        }
+
+        this.calendar = new FullCalendar.Calendar(calendarEl, {
+            initialView: 'dayGridMonth',
+            headerToolbar: {
+                left: 'prev,next today',
+                center: 'title',
+                right: 'dayGridMonth,dayGridWeek'
+            },
+            height: 'auto',
+            events: this.loadCalendarEvents.bind(this),
+            eventClick: this.handleEventClick.bind(this),
+            eventContent: this.renderEventContent.bind(this),
+            eventDidMount: this.styleEventElement.bind(this),
+            datesSet: this.onDatesSet.bind(this)
+        });
+
+        this.calendar.render();
+        this.setupModal();
+    }
+
+    async onDatesSet(dateInfo) {
+        // Load data when the calendar view changes (month navigation)  
+        await this.loadPnlData(dateInfo.startStr, dateInfo.endStr);
+        // Note: updateMonthlyPnlSummary will be called in loadCalendarEvents
+    }
+
+    async loadPnlData(startDate, endDate) {
+        try {
+            const response = await fetch(`/api/daily-pnl?start_date=${startDate}&end_date=${endDate}`);
+            const data = await response.json();
+
+            // Stocks API returns {daily_pnl: {...}} directly, no success field
+            if (data.daily_pnl) {
+                this.dailyPnlData = data.daily_pnl;
+            } else {
+                console.error('Failed to load daily P&L data:', data.error);
+            }
+        } catch (error) {
+            console.error('Error fetching daily P&L data:', error);
+        }
+    }
+
+    updateMonthlyPnlSummary(dateInfo) {
+        // Get the actual month/year being displayed (center of the view)
+        const viewStart = new Date(dateInfo.start);
+        const viewEnd = new Date(dateInfo.end);
+        const middleDate = new Date((viewStart.getTime() + viewEnd.getTime()) / 2);
+        
+        const targetMonth = middleDate.getMonth();
+        const targetYear = middleDate.getFullYear();
+        
+        // Calculate total P&L only for days in the target month
+        let monthlyTotal = 0;
+        let tradeDays = 0;
+        
+        for (const [date, dayData] of Object.entries(this.dailyPnlData)) {
+            const dayDate = new Date(date);
+            // Only include days that are in the target month/year
+            if (dayDate.getMonth() === targetMonth && dayDate.getFullYear() === targetYear) {
+                monthlyTotal += dayData.pnl_no_fees || 0;
+                tradeDays++;
+            }
+        }
+        
+        const monthYear = middleDate.toLocaleDateString('en-US', { 
+            month: 'long', 
+            year: 'numeric' 
+        });
+        
+        // Update the calendar title to include monthly P&L
+        const titleElement = document.querySelector('.fc-toolbar-title');
+        if (titleElement) {
+            const pnlClass = monthlyTotal >= 0 ? 'profit' : 'loss';
+            const pnlSign = monthlyTotal >= 0 ? '+' : '';
+            titleElement.innerHTML = `
+                ${monthYear}
+                <div class="monthly-pnl ${pnlClass}" style="font-size: 0.8em; font-weight: normal; margin-top: 4px;">
+                    Monthly P&L: ${pnlSign}$${monthlyTotal.toFixed(2)} (${tradeDays} days)
+                </div>
+            `;
+        }
+    }
+
+    async loadCalendarEvents(info, successCallback, failureCallback) {
+        try {
+            // Load data for the current date range first
+            await this.loadPnlData(info.startStr, info.endStr);
+
+            // Fetch daily summaries to get opened/closed counts
+            const summaries = await this.loadDailySummaries(info.startStr, info.endStr);
+
+            // Convert daily P&L data to FullCalendar events
+            const events = [];
+
+            // Combine both P&L data and summaries to catch days with only opens
+            const allDates = new Set([
+                ...Object.keys(this.dailyPnlData),
+                ...Object.keys(summaries)
+            ]);
+
+            for (const date of allDates) {
+                const dayData = this.dailyPnlData[date] || {};
+                const pnl = dayData.pnl_no_fees || 0;
+                const count = dayData.count || 0;
+                const summary = summaries[date] || { positions_closed: 0, positions_opened: 0 };
+
+                const closed = summary.positions_closed;
+                const opened = summary.positions_opened;
+
+                // Determine event color
+                let backgroundColor, borderColor;
+                if (closed > 0) {
+                    // Has closed positions - show green/red based on P&L
+                    backgroundColor = pnl >= 0 ? '#28a745' : '#dc3545';
+                    borderColor = pnl >= 0 ? '#28a745' : '#dc3545';
+                } else if (opened > 0) {
+                    // Only opened positions - show blue
+                    backgroundColor = '#007bff';
+                    borderColor = '#007bff';
+                } else {
+                    // Skip if no activity
+                    continue;
+                }
+
+                events.push({
+                    id: date,
+                    title: `$${pnl.toFixed(2)}`,
+                    date: date,
+                    extendedProps: {
+                        pnl: pnl,
+                        count: count,
+                        positions_closed: closed,
+                        positions_opened: opened,
+                        details: dayData.details
+                    },
+                    backgroundColor: backgroundColor,
+                    borderColor: borderColor,
+                    textColor: 'white'
+                });
+            }
+
+            // Update the monthly summary after loading events
+            this.updateMonthlyPnlSummary(info);
+
+            successCallback(events);
+        } catch (error) {
+            console.error('Error loading calendar events:', error);
+            failureCallback(error);
+        }
+    }
+
+    async loadDailySummaries(startDate, endDate) {
+        // Get all trading dates (not just days with P&L)
+        const allDatesResponse = await fetch('/api/all-trading-dates');
+        const allDatesData = await allDatesResponse.json();
+
+        if (!allDatesData.success) {
+            console.error('Failed to load trading dates');
+            return {};
+        }
+
+        const summaries = {};
+
+        // Load summaries for all trading dates in range
+        for (const date of allDatesData.dates) {
+            // Filter by date range
+            if (date < startDate || date > endDate) {
+                continue;
+            }
+
+            try {
+                const response = await fetch(`/api/daily-summary/${date}`);
+                const data = await response.json();
+                if (data.success && data.summary) {
+                    const totals = data.summary.totals;
+                    // Only include if there's actual activity
+                    if (totals.positions_closed > 0 || totals.positions_opened > 0) {
+                        summaries[date] = {
+                            positions_closed: totals.positions_closed,
+                            positions_opened: totals.positions_opened
+                        };
+                    }
+                }
+            } catch (error) {
+                console.error(`Error loading summary for ${date}:`, error);
+            }
+        }
+
+        return summaries;
+    }
+
+    renderEventContent(eventInfo) {
+        const pnl = eventInfo.event.extendedProps.pnl;
+        const closed = eventInfo.event.extendedProps.positions_closed || 0;
+        const opened = eventInfo.event.extendedProps.positions_opened || 0;
+
+        // Build label showing only non-zero counts
+        let label = '';
+        if (closed > 0 && opened > 0) {
+            label = `${closed} closed, ${opened} opened`;
+        } else if (closed > 0) {
+            label = `${closed} closed`;
+        } else if (opened > 0) {
+            label = `${opened} opened`;
+        }
+
+        return {
+            html: `
+                <div class="pnl-event">
+                    <div class="pnl-amount">$${pnl.toFixed(2)}</div>
+                    <div class="pnl-count">${label}</div>
+                </div>
+            `
+        };
+    }
+
+    styleEventElement(eventInfo) {
+        const element = eventInfo.el;
+        element.style.cursor = 'pointer';
+        element.style.fontSize = '11px';
+        element.style.padding = '2px';
+    }
+
+    async handleEventClick(eventInfo) {
+        const date = eventInfo.event.id;
+        const pnl = eventInfo.event.extendedProps.pnl;
+        const count = eventInfo.event.extendedProps.count;
+        
+        await this.showPositionDetails(date, pnl, count);
+    }
+
+    async showPositionDetails(date, pnl, count) {
+        try {
+            // Fetch both summary and detailed orders
+            const [summaryResponse, ordersResponse] = await Promise.all([
+                fetch(`/api/daily-summary/${date}`),
+                fetch(`/api/positions/date/${date}`)
+            ]);
+
+            const summaryData = await summaryResponse.json();
+            const ordersData = await ordersResponse.json();
+
+            if (!summaryData.success || !ordersData.success) {
+                alert('Failed to load order details');
+                return;
+            }
+
+            const modal = document.getElementById('positionModal');
+            const title = document.getElementById('modalTitle');
+            const body = document.getElementById('modalPositions');
+
+            title.textContent = `Trading Summary - ${date}`;
+
+            // Format dates to be more readable (in Eastern time to match market hours)
+            const formatDate = (dateStr) => {
+                if (!dateStr) return '';
+                const date = new Date(dateStr);
+                return date.toLocaleString('en-US', {
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    timeZone: 'America/New_York'
+                });
+            };
+
+            const summary = summaryData.summary;
+
+            // Summary header with stats
+            let html = `
+                <div style="margin-bottom: 20px; padding: 10px; background: #f5f5f5; border-radius: 4px;">
+                    <strong>Daily Summary:</strong>
+                    ${summary.totals.positions_closed} position(s) closed,
+                    ${summary.totals.positions_opened} position(s) opened
+                    <br>
+                    <strong>Realized P&L:</strong>
+                    <span class="${summary.totals.total_pnl >= 0 ? 'profit' : 'loss'}">
+                        ${summary.totals.total_pnl >= 0 ? '+' : ''}$${summary.totals.total_pnl.toFixed(2)}
+                    </span>
+                </div>
+            `;
+
+            // Closed Positions Table
+            if (summary.closed_positions && summary.closed_positions.length > 0) {
+                html += `
+                    <h3>Closed Positions</h3>
+                    <table class="position-details-table">
+                        <thead>
+                            <tr>
+                                <th>Symbol</th>
+                                <th>Quantity</th>
+                                <th>Avg Buy Price</th>
+                                <th>Avg Sell Price</th>
+                                <th>P&L</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                `;
+
+                summary.closed_positions.forEach(pos => {
+                    const pnlClass = pos.pnl >= 0 ? 'profit' : 'loss';
+                    const pnlSign = pos.pnl >= 0 ? '+' : '';
+
+                    html += `
+                        <tr>
+                            <td><strong>${pos.symbol}</strong></td>
+                            <td>${pos.quantity}</td>
+                            <td>$${pos.avg_buy_price.toFixed(2)}</td>
+                            <td>$${pos.avg_sell_price.toFixed(2)}</td>
+                            <td class="${pnlClass}">${pnlSign}$${pos.pnl.toFixed(2)}</td>
+                        </tr>
+                    `;
+                });
+
+                html += `
+                        </tbody>
+                    </table>
+                    <br>
+                `;
+            }
+
+            // Opened Positions Table
+            if (summary.opened_positions && summary.opened_positions.length > 0) {
+                html += `
+                    <h3>Opened Positions</h3>
+                    <table class="position-details-table">
+                        <thead>
+                            <tr>
+                                <th>Symbol</th>
+                                <th>Quantity</th>
+                                <th>Avg Buy Price</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                `;
+
+                summary.opened_positions.forEach(pos => {
+                    html += `
+                        <tr>
+                            <td><strong>${pos.symbol}</strong></td>
+                            <td>${pos.quantity}</td>
+                            <td>$${pos.avg_buy_price.toFixed(2)}</td>
+                        </tr>
+                    `;
+                });
+
+                html += `
+                        </tbody>
+                    </table>
+                    <br>
+                `;
+            }
+
+            html += `
+                <h3>Detailed Orders (${count} total)</h3>
+                <table class="position-details-table">
+                    <thead>
+                        <tr>
+                            <th>Symbol</th>
+                            <th>Time</th>
+                            <th>Side</th>
+                            <th>Quantity</th>
+                            <th>Price</th>
+                            <th>Total Amount</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+            `;
+
+            ordersData.orders.forEach(order => {
+                const sideClass = order.side === 'buy' ? 'buy' : 'sell';
+
+                html += `
+                    <tr>
+                        <td>${order.symbol}</td>
+                        <td>${formatDate(order.execution_time)}</td>
+                        <td class="${sideClass}">${order.side.toUpperCase()}</td>
+                        <td>${order.quantity}</td>
+                        <td>$${order.average_price.toFixed(2)}</td>
+                        <td>$${order.total_amount.toFixed(2)}</td>
+                    </tr>
+                `;
+            });
+
+            html += '</tbody></table>';
+            body.innerHTML = html;
+
+            modal.style.display = 'block';
+
+        } catch (error) {
+            console.error('Error loading order details:', error);
+            alert('Error loading order details');
+        }
+    }
+
+    setupModal() {
+        const modal = document.getElementById('positionModal');
+        const closeBtn = modal.querySelector('.close');
+        
+        closeBtn.addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+        
+        window.addEventListener('click', (event) => {
+            if (event.target === modal) {
+                modal.style.display = 'none';
+            }
+        });
+    }
+
+    async refreshCalendar() {
+        if (this.calendar) {
+            await this.calendar.refetchEvents();
+        }
+    }
+
+    destroy() {
+        if (this.calendar) {
+            this.calendar.destroy();
+            this.calendar = null;
+        }
+    }
+}
+
+// Global calendar manager instance
+let calendarManager = null;
+
+// Initialize calendar when the calendar tab is shown
+function initCalendar() {
+    if (!calendarManager) {
+        calendarManager = new CalendarManager();
+    }
+    calendarManager.initCalendar();
+}
+
+// Clean up calendar when switching away
+function destroyCalendar() {
+    if (calendarManager) {
+        calendarManager.destroy();
+        calendarManager = null;
+    }
+}
+
+// Refresh calendar data
+async function refreshCalendar() {
+    if (calendarManager) {
+        await calendarManager.refreshCalendar();
+    }
+}

--- a/stocks/static/js/main.js
+++ b/stocks/static/js/main.js
@@ -1,0 +1,532 @@
+// Main JavaScript for Stocks Dashboard
+let stocksData = null;
+let currentFilter = { startDate: null, endDate: null };
+
+// Load data on page load
+document.addEventListener('DOMContentLoaded', () => {
+    loadStocksData();
+    setupEventListeners();
+});
+
+function setupEventListeners() {
+    // Refresh button
+    const refreshBtn = document.getElementById('refreshBtn');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', refreshData);
+    }
+
+    // Tab switching
+    document.querySelectorAll('.tab').forEach(tab => {
+        tab.addEventListener('click', () => switchTab(tab.dataset.tab));
+    });
+
+    // Date filter buttons
+    document.getElementById('applyFilter').addEventListener('click', applyDateFilter);
+    document.getElementById('clearFilter').addEventListener('click', clearDateFilter);
+}
+
+function switchTab(tabName) {
+    // Update active tab
+    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+
+    document.querySelector(`[data-tab="${tabName}"]`).classList.add('active');
+    document.getElementById(tabName).classList.add('active');
+
+    // Initialize calendar if switching to calendar tab
+    if (tabName === 'calendar') {
+        if (!window.calendarManager) {
+            window.calendarManager = new CalendarManager();
+            window.calendarManager.initCalendar();
+        }
+    }
+}
+
+async function loadStocksData() {
+    try {
+        showLoading();
+
+        // Fetch main data
+        const response = await fetch('/api/stocks');
+        const data = await response.json();
+
+        if (data.error) {
+            showError(data.error);
+            return;
+        }
+
+        // Fetch open positions separately (requires login)
+        try {
+            const posResponse = await fetch('/api/open-positions');
+            const posData = await posResponse.json();
+            if (posData.success && posData.open_positions) {
+                data.open_positions = posData.open_positions;
+                // Update summary with unrealized P&L
+                const unrealized_pnl = posData.open_positions.reduce((sum, pos) => sum + pos.unrealized_pnl, 0);
+                data.summary.total_unrealized_pnl = unrealized_pnl;
+                data.summary.num_open_positions = posData.open_positions.length;
+            }
+        } catch (e) {
+            console.log('Could not fetch open positions:', e);
+        }
+
+        // Fetch closed positions
+        try {
+            const closedResponse = await fetch('/api/closed-positions');
+            const closedData = await closedResponse.json();
+            if (closedData.success && closedData.closed_positions) {
+                data.closed_positions = closedData.closed_positions;
+            }
+        } catch (e) {
+            console.log('Could not fetch closed positions:', e);
+        }
+
+        stocksData = data;
+        renderDashboard(data);
+        hideLoading();
+
+    } catch (error) {
+        console.error('Error loading stocks data:', error);
+        showError('Failed to load stocks data');
+    }
+}
+
+async function refreshData() {
+    try {
+        showLoading('Refreshing data from Robinhood...');
+
+        const response = await fetch('/api/update', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        });
+
+        const result = await response.json();
+
+        if (result.error) {
+            showError(result.error);
+            return;
+        }
+
+        // Reload the data
+        await loadStocksData();
+
+        // Refresh calendar if visible
+        if (window.calendarManager) {
+            await window.calendarManager.refreshCalendar();
+        }
+
+    } catch (error) {
+        console.error('Error refreshing data:', error);
+        showError('Failed to refresh data');
+    }
+}
+
+function renderDashboard(data) {
+    renderSummary(data.summary);
+    renderOpenPositions(data.open_positions || []);
+    renderClosedPositions(data.closed_positions || []);
+    renderBySymbol(data.closed_positions || []);
+    renderOrders(data.all_orders);
+}
+
+function renderSummary(summary) {
+    const summaryDiv = document.getElementById('summary');
+    const pnlClass = summary.total_pnl >= 0 ? 'profit' : 'loss';
+    const pnlSign = summary.total_pnl >= 0 ? '+' : '';
+    const unrealizedClass = summary.total_unrealized_pnl >= 0 ? 'profit' : 'loss';
+    const unrealizedSign = summary.total_unrealized_pnl >= 0 ? '+' : '';
+
+    summaryDiv.innerHTML = `
+        <div class="summary-card">
+            <h3>Realized P&L</h3>
+            <div class="summary-value ${pnlClass}">${pnlSign}$${summary.total_pnl.toFixed(2)}</div>
+        </div>
+        <div class="summary-card">
+            <h3>Unrealized P&L</h3>
+            <div class="summary-value ${unrealizedClass}">${unrealizedSign}$${summary.total_unrealized_pnl.toFixed(2)}</div>
+        </div>
+        <div class="summary-card">
+            <h3>Win Rate</h3>
+            <div class="summary-value">${summary.win_rate}%</div>
+            <div style="font-size: 0.8em; margin-top: 5px;">${summary.winning_trades}W / ${summary.losing_trades}L</div>
+        </div>
+        <div class="summary-card">
+            <h3>Open Positions</h3>
+            <div class="summary-value">${summary.num_open_positions}</div>
+        </div>
+        <div class="summary-card">
+            <h3>Closed Positions</h3>
+            <div class="summary-value">${summary.total_closed_positions}</div>
+        </div>
+        <div class="summary-card">
+            <h3>Trading Days</h3>
+            <div class="summary-value">${summary.num_trading_days} / ${summary.approx_market_days}</div>
+        </div>
+    `;
+}
+
+function renderOpenPositions(positions) {
+    const positionsDiv = document.getElementById('openPositions');
+
+    let html = '<h2>Open Positions</h2>';
+
+    if (positions.length === 0) {
+        html += '<p>No open positions</p>';
+    } else {
+        html += '<table class="positions-table">';
+        html += '<thead><tr>';
+        html += '<th>Symbol</th>';
+        html += '<th>Quantity</th>';
+        html += '<th>Avg Buy Price</th>';
+        html += '<th>Current Price</th>';
+        html += '<th>Cost Basis</th>';
+        html += '<th>Market Value</th>';
+        html += '<th>Unrealized P&L</th>';
+        html += '</tr></thead><tbody>';
+
+        positions.forEach(pos => {
+            const pnlClass = pos.unrealized_pnl >= 0 ? 'profit' : 'loss';
+            const pnlSign = pos.unrealized_pnl >= 0 ? '+' : '';
+
+            html += '<tr>';
+            html += `<td><strong>${pos.symbol}</strong></td>`;
+            html += `<td>${pos.quantity}</td>`;
+            html += `<td>$${pos.average_buy_price.toFixed(2)}</td>`;
+            html += `<td>$${pos.current_price.toFixed(2)}</td>`;
+            html += `<td>$${pos.cost_basis.toFixed(2)}</td>`;
+            html += `<td>$${pos.market_value.toFixed(2)}</td>`;
+            html += `<td class="${pnlClass}">${pnlSign}$${pos.unrealized_pnl.toFixed(2)}</td>`;
+            html += '</tr>';
+        });
+
+        html += '</tbody></table>';
+    }
+
+    positionsDiv.innerHTML = html;
+}
+
+function renderClosedPositions(positions) {
+    const positionsDiv = document.getElementById('closedPositions');
+
+    let html = '<h2>Closed Positions (FIFO Matched)</h2>';
+
+    if (positions.length === 0) {
+        html += '<p>No closed positions</p>';
+    } else {
+        html += '<table class="positions-table">';
+        html += '<thead><tr>';
+        html += '<th>Symbol</th>';
+        html += '<th>Quantity</th>';
+        html += '<th>Buy Date</th>';
+        html += '<th>Sell Date</th>';
+        html += '<th>Avg Buy Price</th>';
+        html += '<th>Avg Sell Price</th>';
+        html += '<th>P&L</th>';
+        html += '</tr></thead><tbody>';
+
+        positions.forEach(pos => {
+            const pnlClass = pos.pnl >= 0 ? 'profit' : 'loss';
+            const pnlSign = pos.pnl >= 0 ? '+' : '';
+
+            html += '<tr>';
+            html += `<td><strong>${pos.symbol}</strong></td>`;
+            html += `<td>${pos.quantity}</td>`;
+            html += `<td>${pos.buy_date}</td>`;
+            html += `<td>${pos.sell_date}</td>`;
+            html += `<td>$${pos.buy_price.toFixed(2)}</td>`;
+            html += `<td>$${pos.sell_price.toFixed(2)}</td>`;
+            html += `<td class="${pnlClass}">${pnlSign}$${pos.pnl.toFixed(2)}</td>`;
+            html += '</tr>';
+        });
+
+        html += '</tbody></table>';
+    }
+
+    positionsDiv.innerHTML = html;
+}
+
+function renderBySymbol(closedPositions) {
+    const symbolDiv = document.getElementById('bySymbol');
+
+    // Group by symbol and calculate totals
+    const symbolStats = {};
+
+    closedPositions.forEach(pos => {
+        const symbol = pos.symbol;
+        if (!symbolStats[symbol]) {
+            symbolStats[symbol] = {
+                symbol: symbol,
+                total_pnl: 0,
+                total_quantity: 0,
+                num_trades: 0,
+                winning_trades: 0,
+                losing_trades: 0
+            };
+        }
+
+        symbolStats[symbol].total_pnl += pos.pnl;
+        symbolStats[symbol].total_quantity += pos.quantity;
+        symbolStats[symbol].num_trades += 1;
+
+        if (pos.pnl > 0) {
+            symbolStats[symbol].winning_trades += 1;
+        } else if (pos.pnl < 0) {
+            symbolStats[symbol].losing_trades += 1;
+        }
+    });
+
+    // Convert to array and sort by total P&L (descending)
+    const symbolArray = Object.values(symbolStats).sort((a, b) => b.total_pnl - a.total_pnl);
+
+    let html = '<h2>P&L by Symbol</h2>';
+
+    if (symbolArray.length === 0) {
+        html += '<p>No closed positions</p>';
+    } else {
+        // Heatmap visualization
+        html += '<div style="margin-bottom: 30px;">';
+        html += '<h3>Heatmap</h3>';
+        html += '<div class="heatmap-container">';
+
+        // Find max absolute P&L for sizing
+        const maxAbsPnl = Math.max(...symbolArray.map(s => Math.abs(s.total_pnl)));
+
+        symbolArray.forEach(stat => {
+            const pnl = stat.total_pnl;
+            const absPnl = Math.abs(pnl);
+
+            // Size: smaller range to fit on one page (50px to 150px)
+            const minSize = 50;
+            const maxSize = 150;
+            const sizeRange = maxSize - minSize;
+            // Use square root for better distribution
+            const sizeFactor = Math.sqrt(absPnl / maxAbsPnl);
+            const size = minSize + (sizeFactor * sizeRange);
+
+            // Scale font sizes with box size (more aggressive scaling)
+            const symbolSize = Math.max(0.6, size / 100); // Ticker scales with box
+            const pnlSize = Math.max(0.7, size / 90);      // P&L scales with box
+            const detailSize = Math.max(0.5, size / 140);  // Details scale with box
+
+            // Color intensity based on P&L magnitude
+            let backgroundColor, textColor;
+            if (pnl > 0) {
+                // Green for profit - darker green for higher profit
+                const intensity = Math.min(absPnl / maxAbsPnl, 1);
+                const greenValue = Math.floor(80 + intensity * 120); // 80-200
+                backgroundColor = `rgb(34, ${greenValue}, 34)`;
+                textColor = 'white';
+            } else if (pnl < 0) {
+                // Red for loss - darker red for higher loss
+                const intensity = Math.min(absPnl / maxAbsPnl, 1);
+                const redValue = Math.floor(80 + intensity * 120); // 80-200
+                backgroundColor = `rgb(${redValue}, 34, 34)`;
+                textColor = 'white';
+            } else {
+                backgroundColor = '#888';
+                textColor = 'white';
+            }
+
+            const pnlSign = pnl >= 0 ? '+' : '';
+            const winRate = stat.num_trades > 0 ? (stat.winning_trades / stat.num_trades * 100) : 0;
+
+            // Only show win rate if box is big enough (>80px) and has 3+ trades
+            const showWinRate = size > 80 && stat.num_trades >= 3;
+
+            html += `
+                <div class="heatmap-box" style="
+                    width: ${size}px;
+                    height: ${size}px;
+                    background-color: ${backgroundColor};
+                    color: ${textColor};
+                ">
+                    <div class="heatmap-symbol" style="font-size: ${symbolSize}em;">${stat.symbol}</div>
+                    <div class="heatmap-pnl" style="font-size: ${pnlSize}em;">${pnlSign}$${pnl.toFixed(0)}</div>
+                    ${showWinRate ? `<div class="heatmap-trades" style="font-size: ${detailSize}em;">${stat.num_trades} trades</div>` : ''}
+                    ${showWinRate ? `<div class="heatmap-winrate" style="font-size: ${detailSize}em;">${winRate.toFixed(0)}% WR</div>` : ''}
+                </div>
+            `;
+        });
+
+        html += '</div></div>';
+
+        // Table view
+        html += '<h3>Detailed Breakdown</h3>';
+        html += '<table class="positions-table">';
+        html += '<thead><tr>';
+        html += '<th>Symbol</th>';
+        html += '<th>Total P&L</th>';
+        html += '<th>Trades</th>';
+        html += '<th>Win Rate</th>';
+        html += '<th>Avg P&L per Trade</th>';
+        html += '</tr></thead><tbody>';
+
+        symbolArray.forEach(stat => {
+            const pnlClass = stat.total_pnl >= 0 ? 'profit' : 'loss';
+            const pnlSign = stat.total_pnl >= 0 ? '+' : '';
+            const winRate = stat.num_trades > 0 ? (stat.winning_trades / stat.num_trades * 100) : 0;
+            const avgPnl = stat.num_trades > 0 ? stat.total_pnl / stat.num_trades : 0;
+            const avgPnlClass = avgPnl >= 0 ? 'profit' : 'loss';
+            const avgPnlSign = avgPnl >= 0 ? '+' : '';
+
+            html += '<tr>';
+            html += `<td><strong>${stat.symbol}</strong></td>`;
+            html += `<td class="${pnlClass}">${pnlSign}$${stat.total_pnl.toFixed(2)}</td>`;
+            html += `<td>${stat.num_trades} (${stat.winning_trades}W / ${stat.losing_trades}L)</td>`;
+            html += `<td>${winRate.toFixed(1)}%</td>`;
+            html += `<td class="${avgPnlClass}">${avgPnlSign}$${avgPnl.toFixed(2)}</td>`;
+            html += '</tr>';
+        });
+
+        html += '</tbody></table>';
+    }
+
+    symbolDiv.innerHTML = html;
+}
+
+function renderOrders(orders) {
+    const ordersDiv = document.getElementById('allOrders');
+
+    let html = '<h2>All Stock Orders</h2>';
+    html += '<table class="orders-table">';
+    html += '<thead><tr>';
+    html += '<th>Date</th>';
+    html += '<th>Symbol</th>';
+    html += '<th>Side</th>';
+    html += '<th>Quantity</th>';
+    html += '<th>Price</th>';
+    html += '<th>Total</th>';
+    html += '</tr></thead><tbody>';
+
+    orders.forEach(order => {
+        const date = new Date(order.last_transaction_at).toLocaleDateString();
+        const sideClass = order.side === 'buy' ? 'buy' : 'sell';
+
+        html += '<tr>';
+        html += `<td>${date}</td>`;
+        html += `<td>${order.symbol}</td>`;
+        html += `<td class="${sideClass}">${order.side.toUpperCase()}</td>`;
+        html += `<td>${order.quantity}</td>`;
+        html += `<td>$${order.average_price.toFixed(2)}</td>`;
+        html += `<td>$${order.total_amount.toFixed(2)}</td>`;
+        html += '</tr>';
+    });
+
+    html += '</tbody></table>';
+    ordersDiv.innerHTML = html;
+}
+
+function showLoading(message = 'Loading...') {
+    document.getElementById('loadingIndicator').textContent = message;
+    document.getElementById('loadingIndicator').style.display = 'block';
+    document.getElementById('errorMessage').style.display = 'none';
+    document.getElementById('dashboardContent').style.display = 'none';
+}
+
+function hideLoading() {
+    document.getElementById('loadingIndicator').style.display = 'none';
+    document.getElementById('dashboardContent').style.display = 'block';
+}
+
+function showError(message) {
+    document.getElementById('errorMessage').textContent = message;
+    document.getElementById('errorMessage').style.display = 'block';
+    document.getElementById('loadingIndicator').style.display = 'none';
+}
+
+function applyDateFilter() {
+    const startDate = document.getElementById('startDate').value;
+    const endDate = document.getElementById('endDate').value;
+
+    currentFilter.startDate = startDate || null;
+    currentFilter.endDate = endDate || null;
+
+    // Re-render with filtered data
+    renderFilteredData();
+}
+
+function clearDateFilter() {
+    document.getElementById('startDate').value = '';
+    document.getElementById('endDate').value = '';
+    currentFilter.startDate = null;
+    currentFilter.endDate = null;
+
+    // Re-render with all data
+    renderFilteredData();
+}
+
+function renderFilteredData() {
+    if (!stocksData) return;
+
+    // Filter closed positions
+    const filteredClosed = filterByDateRange(
+        stocksData.closed_positions || [],
+        'sell_date'
+    );
+
+    // Filter all orders
+    const filteredOrders = filterByDateRange(
+        stocksData.all_orders || [],
+        'trade_date'
+    );
+
+    // Calculate filtered summary stats
+    const filteredSummary = calculateFilteredSummary(filteredClosed, filteredOrders);
+
+    // Re-render
+    renderSummary(filteredSummary);
+    renderClosedPositions(filteredClosed);
+    renderBySymbol(filteredClosed);
+    renderOrders(filteredOrders);
+}
+
+function filterByDateRange(items, dateField) {
+    if (!currentFilter.startDate && !currentFilter.endDate) {
+        return items;
+    }
+
+    return items.filter(item => {
+        const itemDate = item[dateField];
+        if (!itemDate) return false;
+
+        if (currentFilter.startDate && itemDate < currentFilter.startDate) {
+            return false;
+        }
+        if (currentFilter.endDate && itemDate > currentFilter.endDate) {
+            return false;
+        }
+        return true;
+    });
+}
+
+function calculateFilteredSummary(closedPositions, allOrders) {
+    // Calculate stats from filtered data
+    const totalPnl = closedPositions.reduce((sum, pos) => sum + pos.pnl, 0);
+    const winningTrades = closedPositions.filter(pos => pos.pnl > 0).length;
+    const losingTrades = closedPositions.filter(pos => pos.pnl < 0).length;
+    const totalClosed = closedPositions.length;
+    const winRate = totalClosed > 0 ? (winningTrades / totalClosed * 100) : 0;
+
+    // Get unique trading dates from filtered orders
+    const tradingDates = new Set(allOrders.map(o => o.trade_date).filter(d => d));
+    const numTradingDays = tradingDates.size;
+
+    // Keep original values for non-filtered fields
+    const originalSummary = stocksData.summary;
+
+    return {
+        total_pnl: totalPnl,
+        total_unrealized_pnl: originalSummary.total_unrealized_pnl,  // Not filtered
+        total_fees: originalSummary.total_fees,
+        num_orders: allOrders.length,
+        num_open_positions: originalSummary.num_open_positions,  // Not filtered
+        num_trading_days: numTradingDays,
+        approx_market_days: originalSummary.approx_market_days,  // Keep original
+        total_closed_positions: totalClosed,
+        winning_trades: winningTrades,
+        losing_trades: losingTrades,
+        win_rate: Math.round(winRate * 10) / 10
+    };
+}

--- a/stocks/stocks_web.py
+++ b/stocks/stocks_web.py
@@ -1,0 +1,215 @@
+import json
+import traceback
+from flask import Flask, render_template, jsonify, request, url_for, send_from_directory, redirect
+from stocks.data_fetcher import StocksDataFetcher
+
+# Initialize Flask app
+app = Flask(__name__, static_url_path='/static', static_folder='static', template_folder='templates')
+
+# Initialize the stocks data fetcher
+data_fetcher = StocksDataFetcher()
+
+# Add route to serve static files
+@app.route('/static/<path:path>')
+def send_static(path):
+    return send_from_directory('static', path)
+
+@app.route('/')
+def index():
+    """Render the main page"""
+    return render_template('index.html')
+
+@app.route('/api/stocks')
+def get_stocks():
+    """API endpoint to get stocks data as JSON"""
+    try:
+        result = data_fetcher.get_processed_data()
+
+        # Check if there's an error
+        if result and 'error' in result and result['error']:
+            return jsonify({
+                'error': result['message'],
+                'details': result.get('traceback', '')
+            }), 500
+
+        return jsonify(result)
+
+    except Exception as e:
+        print(f"API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            "error": "An internal error occurred while fetching stocks data"
+        }), 500
+
+@app.route('/api/update', methods=['POST'])
+def update_data():
+    """API endpoint to update data from Robinhood"""
+    try:
+        result = data_fetcher.update_data()
+
+        if 'error' in result:
+            return jsonify({
+                'error': result['error'],
+                'details': result.get('traceback', '')
+            }), 500
+
+        return jsonify({
+            'success': True,
+            'message': 'Data updated successfully',
+            'data': result
+        })
+
+    except Exception as e:
+        print(f"Update API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            "error": "An internal error occurred while updating data"
+        }), 500
+
+@app.route('/api/daily-pnl')
+def get_daily_pnl():
+    """API endpoint for calendar daily PnL data"""
+    try:
+        start_date = request.args.get('start_date')
+        end_date = request.args.get('end_date')
+
+        daily_pnl = data_fetcher.db.get_daily_pnl(start_date, end_date)
+
+        return jsonify({
+            'success': True,
+            'daily_pnl': daily_pnl
+        })
+
+    except Exception as e:
+        print(f"Daily PnL API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': 'Failed to fetch daily PnL data'
+        }), 500
+
+@app.route('/api/positions/date/<date>')
+def get_positions_by_date(date):
+    """Get all orders for a specific trade date"""
+    try:
+        orders_on_date = data_fetcher.db.get_orders_by_trade_date(date)
+
+        return jsonify({
+            'success': True,
+            'date': date,
+            'orders': orders_on_date
+        })
+
+    except Exception as e:
+        print(f"Orders by Date API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': f'Failed to fetch orders for date {date}'
+        }), 500
+
+@app.route('/api/daily-summary/<date>')
+def get_daily_summary(date):
+    """Get daily trading summary"""
+    try:
+        summary = data_fetcher.db.get_daily_summary(date)
+
+        return jsonify({
+            'success': True,
+            'summary': summary
+        })
+
+    except Exception as e:
+        print(f"Daily Summary API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': f'Failed to fetch summary for date {date}'
+        }), 500
+
+@app.route('/api/open-positions')
+def get_open_positions_api():
+    """Get current open positions from Robinhood"""
+    try:
+        # Login if needed
+        if not data_fetcher.login_robinhood():
+            return jsonify({
+                'error': 'Failed to login to Robinhood'
+            }), 401
+
+        positions = data_fetcher.get_open_positions()
+
+        return jsonify({
+            'success': True,
+            'open_positions': positions
+        })
+
+    except Exception as e:
+        print(f"Open Positions API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': 'Failed to fetch open positions'
+        }), 500
+
+@app.route('/api/closed-positions')
+def get_closed_positions_api():
+    """Get closed positions with FIFO P&L"""
+    try:
+        closed_positions = data_fetcher.db.get_closed_positions()
+
+        return jsonify({
+            'success': True,
+            'closed_positions': closed_positions
+        })
+
+    except Exception as e:
+        print(f"Closed Positions API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': 'Failed to fetch closed positions'
+        }), 500
+
+@app.route('/api/all-trading-dates')
+def get_all_trading_dates():
+    """Get all unique trading dates from orders"""
+    try:
+        dates = data_fetcher.db.get_all_trading_dates()
+
+        return jsonify({
+            'success': True,
+            'dates': dates
+        })
+
+    except Exception as e:
+        print(f"All Trading Dates API Error: {str(e)}")
+        print(traceback.format_exc())
+
+        return jsonify({
+            'error': 'Failed to fetch trading dates'
+        }), 500
+
+
+if __name__ == '__main__':
+    # Start server
+    print("Starting Robinhood Stocks Dashboard...")
+
+    import os
+
+    # Check if database has orders, if not, auto-fetch
+    try:
+        result = data_fetcher.get_processed_data(include_open_positions=False)
+        if result.get('all_orders') is not None and len(result['all_orders']) == 0:
+            print("No orders found in database, fetching from Robinhood...")
+            data_fetcher.update_data()
+            print("Initial data fetch complete.")
+        else:
+            print(f"Loaded {len(result.get('all_orders', []))} existing orders from database.")
+    except Exception as e:
+        print(f"Could not auto-fetch data: {e}")
+        print("You can manually refresh data using the 'Refresh Data' button.")
+
+    app.run(debug=True, host='0.0.0.0', port=3002)

--- a/stocks/templates/index.html
+++ b/stocks/templates/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Robinhood Stocks Dashboard</title>
+    <link rel="stylesheet" href="/static/css/styles.css">
+</head>
+<body>
+    <header>
+        <h1>Robinhood Stocks Dashboard</h1>
+        <button id="refreshBtn">Refresh Data</button>
+    </header>
+
+    <div class="container">
+        <div id="loadingIndicator" class="loading">Loading stocks data...</div>
+        <div id="errorMessage" class="error" style="display: none;"></div>
+
+        <div id="dashboardContent" style="display: none;">
+            <!-- Date Range Filter -->
+            <div class="filters" style="margin: 20px 0; padding: 15px; background: #f5f5f5; border-radius: 4px;">
+                <label for="startDate">Start Date:</label>
+                <input type="date" id="startDate" style="margin-right: 20px;">
+
+                <label for="endDate">End Date:</label>
+                <input type="date" id="endDate" style="margin-right: 20px;">
+
+                <button id="applyFilter">Apply Filter</button>
+                <button id="clearFilter">Clear Filter</button>
+            </div>
+
+            <div id="summary" class="summary">
+                <!-- Summary cards will be inserted here -->
+            </div>
+
+            <div class="tabs">
+                <div class="tab active" data-tab="openPositions">Open Positions</div>
+                <div class="tab" data-tab="closedPositions">Closed Positions</div>
+                <div class="tab" data-tab="bySymbol">By Symbol</div>
+                <div class="tab" data-tab="allOrders">All Orders</div>
+                <div class="tab" data-tab="calendar">Calendar</div>
+            </div>
+
+            <!-- Open Positions Tab -->
+            <div id="openPositions" class="tab-content active">
+                <!-- Open positions table will be inserted here -->
+            </div>
+
+            <!-- Closed Positions Tab -->
+            <div id="closedPositions" class="tab-content">
+                <!-- Closed positions table will be inserted here -->
+            </div>
+
+            <!-- By Symbol Tab -->
+            <div id="bySymbol" class="tab-content">
+                <!-- Symbol P&L table will be inserted here -->
+            </div>
+
+            <!-- All Orders Tab -->
+            <div id="allOrders" class="tab-content">
+                <!-- Orders table will be inserted here -->
+            </div>
+
+            <!-- Calendar Tab -->
+            <div id="calendar" class="tab-content">
+                <div id="calendarView"></div>
+
+                <!-- Day Detail Modal -->
+                <div id="positionModal" class="modal" style="display: none;">
+                    <div class="modal-content">
+                        <span class="close">&times;</span>
+                        <h2 id="modalTitle"></h2>
+                        <div id="modalPositions"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+    <script src="/static/js/calendar.js"></script>
+    <script src="/static/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Created a minimal stocks trading dashboard with the following features:

Backend (Python/Flask):
- SQLite database with stock_orders table for historical data
- FIFO (First In, First Out) position matching for accurate P&L
- Incremental data fetching from Robinhood API with symbol caching
- Separate tracking of opened vs closed positions
- Calendar API endpoints for daily P&L and trading summaries

Frontend (JavaScript/HTML/CSS):
- Summary cards: Realized P&L, Unrealized P&L, Win Rate, Open/Closed Positions, Trading Days
- Date range filtering for historical analysis (affects all tabs except Open Positions and Calendar)
- Multiple view tabs:
  * Open Positions: Current holdings with unrealized P&L
  * Closed Positions: FIFO-matched positions with buy/sell prices and realized P&L
  * By Symbol: Heatmap visualization and detailed breakdown by ticker
  * All Orders: Complete order history
  * Calendar: Daily P&L view with opened/closed position details

Key Features:
- FIFO position matching ensures accurate P&L calculation
- Win rate calculated from closed positions only
- Trading days shown as ratio (days traded / total market days since start)
- Heatmap with dynamic sizing and color intensity based on P&L magnitude
- Calendar shows positions opened (blue) and closed (green/red) by day
- Auto-fetch on server startup with symbol caching for performance
- Proper trade date extraction with fallback logic for historical orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)