### PR TITLE
Add symbol analysis improvements to stocks dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,10 @@ python -c "from risk_manager.risk_manager_web import app; print('Risk Manager OK
 - No explicit session management or CSRF protection
 - Multi-account operations are isolated by account_number
 
+## Git Commits
+
+Do NOT include AI attribution (Co-Authored-By) in commit messages.
+
 ## Documentation
 
 See `docs/` for detailed architecture and API documentation:

--- a/stocks/static/css/styles.css
+++ b/stocks/static/css/styles.css
@@ -63,6 +63,42 @@ h2 {
 .tab-content.active {
     display: block;
 }
+
+/* Sub-tabs (nested tabs) */
+.sub-tabs {
+    display: flex;
+    border-bottom: 1px solid #ddd;
+    margin-bottom: 20px;
+    margin-top: 10px;
+}
+.sub-tab {
+    padding: 8px 16px;
+    cursor: pointer;
+    background-color: #f9f9f9;
+    border: 1px solid #ddd;
+    border-bottom: none;
+    margin-right: 5px;
+    border-radius: 4px 4px 0 0;
+    transition: all 0.3s ease;
+    font-size: 14px;
+}
+.sub-tab:hover {
+    background-color: #e9e9e9;
+}
+.sub-tab.active {
+    background-color: white;
+    color: #00C805;
+    font-weight: bold;
+    border-color: #ddd;
+    border-bottom: 1px solid white;
+    margin-bottom: -1px;
+}
+.sub-tab-content {
+    display: none;
+}
+.sub-tab-content.active {
+    display: block;
+}
 .filters {
     margin-bottom: 20px;
     padding: 15px;
@@ -115,6 +151,7 @@ th {
     position: sticky;
     top: 0;
     cursor: pointer;
+    z-index: 10;
 }
 th:hover {
     background-color: #00A804;
@@ -513,7 +550,7 @@ tr:hover {
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
     cursor: pointer;
-    transition: transform 0.2s;
+    transition: transform 0.2s, box-shadow 0.2s;
     padding: 8px;
     overflow: hidden;
     text-align: center;

--- a/stocks/static/js/calendar.js
+++ b/stocks/static/js/calendar.js
@@ -281,12 +281,16 @@ class CalendarManager {
 
             const summary = summaryData.summary;
 
+            // Calculate total shares traded from orders
+            const totalSharesTraded = ordersData.orders.reduce((sum, order) => sum + order.quantity, 0);
+
             // Summary header with stats
             let html = `
                 <div style="margin-bottom: 20px; padding: 10px; background: #f5f5f5; border-radius: 4px;">
                     <strong>Daily Summary:</strong>
                     ${summary.totals.positions_closed} position(s) closed,
-                    ${summary.totals.positions_opened} position(s) opened
+                    ${summary.totals.positions_opened} position(s) opened,
+                    ${totalSharesTraded} shares traded
                     <br>
                     <strong>Realized P&L:</strong>
                     <span class="${summary.totals.total_pnl >= 0 ? 'profit' : 'loss'}">
@@ -367,7 +371,7 @@ class CalendarManager {
             }
 
             html += `
-                <h3>Detailed Orders (${count} total)</h3>
+                <h3>Detailed Orders (${ordersData.orders.length} total)</h3>
                 <table class="position-details-table">
                     <thead>
                         <tr>

--- a/stocks/static/js/main.js
+++ b/stocks/static/js/main.js
@@ -20,9 +20,30 @@ function setupEventListeners() {
         tab.addEventListener('click', () => switchTab(tab.dataset.tab));
     });
 
+    // Sub-tab switching (nested tabs)
+    document.querySelectorAll('.sub-tab').forEach(tab => {
+        tab.addEventListener('click', () => switchSubTab(tab.dataset.subtab));
+    });
+
     // Date filter buttons
     document.getElementById('applyFilter').addEventListener('click', applyDateFilter);
     document.getElementById('clearFilter').addEventListener('click', clearDateFilter);
+
+    // Symbol modal close button
+    const symbolModalClose = document.getElementById('symbolModalClose');
+    if (symbolModalClose) {
+        symbolModalClose.addEventListener('click', () => {
+            document.getElementById('symbolModal').style.display = 'none';
+        });
+    }
+
+    // Close modal when clicking outside
+    window.addEventListener('click', (event) => {
+        const symbolModal = document.getElementById('symbolModal');
+        if (event.target === symbolModal) {
+            symbolModal.style.display = 'none';
+        }
+    });
 }
 
 function switchTab(tabName) {
@@ -40,6 +61,15 @@ function switchTab(tabName) {
             window.calendarManager.initCalendar();
         }
     }
+}
+
+function switchSubTab(subtabName) {
+    // Update active sub-tab
+    document.querySelectorAll('.sub-tab').forEach(t => t.classList.remove('active'));
+    document.querySelectorAll('.sub-tab-content').forEach(c => c.classList.remove('active'));
+
+    document.querySelector(`[data-subtab="${subtabName}"]`).classList.add('active');
+    document.getElementById(subtabName).classList.add('active');
 }
 
 async function loadStocksData() {
@@ -124,14 +154,14 @@ async function refreshData() {
 }
 
 function renderDashboard(data) {
-    renderSummary(data.summary);
+    renderSummary(data.summary, data.all_orders);
     renderOpenPositions(data.open_positions || []);
     renderClosedPositions(data.closed_positions || []);
     renderBySymbol(data.closed_positions || []);
     renderOrders(data.all_orders);
 }
 
-function renderSummary(summary) {
+function renderSummary(summary, orders = null) {
     const summaryDiv = document.getElementById('summary');
     const pnlClass = summary.total_pnl >= 0 ? 'profit' : 'loss';
     const pnlSign = summary.total_pnl >= 0 ? '+' : '';
@@ -165,6 +195,30 @@ function renderSummary(summary) {
             <div class="summary-value">${summary.num_trading_days} / ${summary.approx_market_days}</div>
         </div>
     `;
+
+    // Set date filter values to first trade date and today
+    if (orders && orders.length > 0) {
+        const tradeDates = orders
+            .map(o => o.trade_date)
+            .filter(d => d)
+            .sort();
+
+        if (tradeDates.length > 0) {
+            const firstDate = tradeDates[0];
+            const today = new Date().toISOString().split('T')[0]; // Today's date in YYYY-MM-DD format
+
+            const startDateInput = document.getElementById('startDate');
+            const endDateInput = document.getElementById('endDate');
+
+            // Only set if not already filtered
+            if (startDateInput && !currentFilter.startDate) {
+                startDateInput.value = firstDate;
+            }
+            if (endDateInput && !currentFilter.endDate) {
+                endDateInput.value = today;
+            }
+        }
+    }
 }
 
 function renderOpenPositions(positions) {
@@ -248,8 +302,6 @@ function renderClosedPositions(positions) {
 }
 
 function renderBySymbol(closedPositions) {
-    const symbolDiv = document.getElementById('bySymbol');
-
     // Group by symbol and calculate totals
     const symbolStats = {};
 
@@ -280,110 +332,121 @@ function renderBySymbol(closedPositions) {
     // Convert to array and sort by total P&L (descending)
     const symbolArray = Object.values(symbolStats).sort((a, b) => b.total_pnl - a.total_pnl);
 
-    let html = '<h2>P&L by Symbol</h2>';
+    // Render both heatmap and table views
+    renderHeatmap(symbolArray);
+    renderSymbolTable(symbolArray);
+}
+
+function renderHeatmap(symbolArray) {
+    const heatmapDiv = document.getElementById('heatmap');
 
     if (symbolArray.length === 0) {
-        html += '<p>No closed positions</p>';
-    } else {
-        // Heatmap visualization
-        html += '<div style="margin-bottom: 30px;">';
-        html += '<h3>Heatmap</h3>';
-        html += '<div class="heatmap-container">';
-
-        // Find max absolute P&L for sizing
-        const maxAbsPnl = Math.max(...symbolArray.map(s => Math.abs(s.total_pnl)));
-
-        symbolArray.forEach(stat => {
-            const pnl = stat.total_pnl;
-            const absPnl = Math.abs(pnl);
-
-            // Size: smaller range to fit on one page (50px to 150px)
-            const minSize = 50;
-            const maxSize = 150;
-            const sizeRange = maxSize - minSize;
-            // Use square root for better distribution
-            const sizeFactor = Math.sqrt(absPnl / maxAbsPnl);
-            const size = minSize + (sizeFactor * sizeRange);
-
-            // Scale font sizes with box size (more aggressive scaling)
-            const symbolSize = Math.max(0.6, size / 100); // Ticker scales with box
-            const pnlSize = Math.max(0.7, size / 90);      // P&L scales with box
-            const detailSize = Math.max(0.5, size / 140);  // Details scale with box
-
-            // Color intensity based on P&L magnitude
-            let backgroundColor, textColor;
-            if (pnl > 0) {
-                // Green for profit - darker green for higher profit
-                const intensity = Math.min(absPnl / maxAbsPnl, 1);
-                const greenValue = Math.floor(80 + intensity * 120); // 80-200
-                backgroundColor = `rgb(34, ${greenValue}, 34)`;
-                textColor = 'white';
-            } else if (pnl < 0) {
-                // Red for loss - darker red for higher loss
-                const intensity = Math.min(absPnl / maxAbsPnl, 1);
-                const redValue = Math.floor(80 + intensity * 120); // 80-200
-                backgroundColor = `rgb(${redValue}, 34, 34)`;
-                textColor = 'white';
-            } else {
-                backgroundColor = '#888';
-                textColor = 'white';
-            }
-
-            const pnlSign = pnl >= 0 ? '+' : '';
-            const winRate = stat.num_trades > 0 ? (stat.winning_trades / stat.num_trades * 100) : 0;
-
-            // Only show win rate if box is big enough (>80px) and has 3+ trades
-            const showWinRate = size > 80 && stat.num_trades >= 3;
-
-            html += `
-                <div class="heatmap-box" style="
-                    width: ${size}px;
-                    height: ${size}px;
-                    background-color: ${backgroundColor};
-                    color: ${textColor};
-                ">
-                    <div class="heatmap-symbol" style="font-size: ${symbolSize}em;">${stat.symbol}</div>
-                    <div class="heatmap-pnl" style="font-size: ${pnlSize}em;">${pnlSign}$${pnl.toFixed(0)}</div>
-                    ${showWinRate ? `<div class="heatmap-trades" style="font-size: ${detailSize}em;">${stat.num_trades} trades</div>` : ''}
-                    ${showWinRate ? `<div class="heatmap-winrate" style="font-size: ${detailSize}em;">${winRate.toFixed(0)}% WR</div>` : ''}
-                </div>
-            `;
-        });
-
-        html += '</div></div>';
-
-        // Table view
-        html += '<h3>Detailed Breakdown</h3>';
-        html += '<table class="positions-table">';
-        html += '<thead><tr>';
-        html += '<th>Symbol</th>';
-        html += '<th>Total P&L</th>';
-        html += '<th>Trades</th>';
-        html += '<th>Win Rate</th>';
-        html += '<th>Avg P&L per Trade</th>';
-        html += '</tr></thead><tbody>';
-
-        symbolArray.forEach(stat => {
-            const pnlClass = stat.total_pnl >= 0 ? 'profit' : 'loss';
-            const pnlSign = stat.total_pnl >= 0 ? '+' : '';
-            const winRate = stat.num_trades > 0 ? (stat.winning_trades / stat.num_trades * 100) : 0;
-            const avgPnl = stat.num_trades > 0 ? stat.total_pnl / stat.num_trades : 0;
-            const avgPnlClass = avgPnl >= 0 ? 'profit' : 'loss';
-            const avgPnlSign = avgPnl >= 0 ? '+' : '';
-
-            html += '<tr>';
-            html += `<td><strong>${stat.symbol}</strong></td>`;
-            html += `<td class="${pnlClass}">${pnlSign}$${stat.total_pnl.toFixed(2)}</td>`;
-            html += `<td>${stat.num_trades} (${stat.winning_trades}W / ${stat.losing_trades}L)</td>`;
-            html += `<td>${winRate.toFixed(1)}%</td>`;
-            html += `<td class="${avgPnlClass}">${avgPnlSign}$${avgPnl.toFixed(2)}</td>`;
-            html += '</tr>';
-        });
-
-        html += '</tbody></table>';
+        heatmapDiv.innerHTML = '<p>No closed positions</p>';
+        return;
     }
 
-    symbolDiv.innerHTML = html;
+    // Find max absolute P&L for sizing
+    const maxAbsPnl = Math.max(...symbolArray.map(s => Math.abs(s.total_pnl)));
+
+    let html = '<div class="heatmap-container">';
+
+    symbolArray.forEach(stat => {
+        const pnl = stat.total_pnl;
+        const absPnl = Math.abs(pnl);
+
+        // Size: smaller range to fit on one page (50px to 150px)
+        const minSize = 50;
+        const maxSize = 150;
+        const sizeRange = maxSize - minSize;
+        // Use square root for better distribution
+        const sizeFactor = Math.sqrt(absPnl / maxAbsPnl);
+        const size = minSize + (sizeFactor * sizeRange);
+
+        // Scale font sizes with box size (more aggressive scaling)
+        const symbolSize = Math.max(0.6, size / 100); // Ticker scales with box
+        const pnlSize = Math.max(0.7, size / 90);      // P&L scales with box
+        const detailSize = Math.max(0.5, size / 140);  // Details scale with box
+
+        // Color intensity based on P&L magnitude
+        let backgroundColor, textColor;
+        if (pnl > 0) {
+            // Green for profit - darker green for higher profit
+            const intensity = Math.min(absPnl / maxAbsPnl, 1);
+            const greenValue = Math.floor(80 + intensity * 120); // 80-200
+            backgroundColor = `rgb(34, ${greenValue}, 34)`;
+            textColor = 'white';
+        } else if (pnl < 0) {
+            // Red for loss - darker red for higher loss
+            const intensity = Math.min(absPnl / maxAbsPnl, 1);
+            const redValue = Math.floor(80 + intensity * 120); // 80-200
+            backgroundColor = `rgb(${redValue}, 34, 34)`;
+            textColor = 'white';
+        } else {
+            backgroundColor = '#888';
+            textColor = 'white';
+        }
+
+        const pnlSign = pnl >= 0 ? '+' : '';
+        const winRate = stat.num_trades > 0 ? (stat.winning_trades / stat.num_trades * 100) : 0;
+
+        // Only show win rate if box is big enough (>80px) and has 3+ trades
+        const showWinRate = size > 80 && stat.num_trades >= 3;
+
+        html += `
+            <div class="heatmap-box" style="
+                width: ${size}px;
+                height: ${size}px;
+                background-color: ${backgroundColor};
+                color: ${textColor};
+            " onclick="showSymbolTrades('${stat.symbol}')">
+                <div class="heatmap-symbol" style="font-size: ${symbolSize}em;">${stat.symbol}</div>
+                <div class="heatmap-pnl" style="font-size: ${pnlSize}em;">${pnlSign}$${pnl.toFixed(0)}</div>
+                ${showWinRate ? `<div class="heatmap-trades" style="font-size: ${detailSize}em;">${stat.num_trades} trades</div>` : ''}
+                ${showWinRate ? `<div class="heatmap-winrate" style="font-size: ${detailSize}em;">${winRate.toFixed(0)}% WR</div>` : ''}
+            </div>
+        `;
+    });
+
+    html += '</div>';
+    heatmapDiv.innerHTML = html;
+}
+
+function renderSymbolTable(symbolArray) {
+    const tableDiv = document.getElementById('table');
+
+    if (symbolArray.length === 0) {
+        tableDiv.innerHTML = '<p>No closed positions</p>';
+        return;
+    }
+
+    let html = '<table class="positions-table">';
+    html += '<thead><tr>';
+    html += '<th>Symbol</th>';
+    html += '<th>Total P&L</th>';
+    html += '<th>Trades</th>';
+    html += '<th>Win Rate</th>';
+    html += '<th>Avg P&L per Trade</th>';
+    html += '</tr></thead><tbody>';
+
+    symbolArray.forEach(stat => {
+        const pnlClass = stat.total_pnl >= 0 ? 'profit' : 'loss';
+        const pnlSign = stat.total_pnl >= 0 ? '+' : '';
+        const winRate = stat.num_trades > 0 ? (stat.winning_trades / stat.num_trades * 100) : 0;
+        const avgPnl = stat.num_trades > 0 ? stat.total_pnl / stat.num_trades : 0;
+        const avgPnlClass = avgPnl >= 0 ? 'profit' : 'loss';
+        const avgPnlSign = avgPnl >= 0 ? '+' : '';
+
+        html += `<tr onclick="showSymbolTrades('${stat.symbol}')" style="cursor: pointer;">`;
+        html += `<td><strong>${stat.symbol}</strong></td>`;
+        html += `<td class="${pnlClass}">${pnlSign}$${stat.total_pnl.toFixed(2)}</td>`;
+        html += `<td>${stat.num_trades} (${stat.winning_trades}W / ${stat.losing_trades}L)</td>`;
+        html += `<td>${winRate.toFixed(1)}%</td>`;
+        html += `<td class="${avgPnlClass}">${avgPnlSign}$${avgPnl.toFixed(2)}</td>`;
+        html += '</tr>';
+    });
+
+    html += '</tbody></table>';
+    tableDiv.innerHTML = html;
 }
 
 function renderOrders(orders) {
@@ -418,6 +481,152 @@ function renderOrders(orders) {
     ordersDiv.innerHTML = html;
 }
 
+function showSymbolTrades(symbol) {
+    if (!stocksData || !stocksData.all_orders) return;
+
+    // Get all orders for this symbol
+    const symbolOrders = stocksData.all_orders
+        .filter(order => order.symbol === symbol)
+        .sort((a, b) => new Date(a.last_transaction_at) - new Date(b.last_transaction_at));
+
+    if (symbolOrders.length === 0) {
+        return;
+    }
+
+    // Get closed positions (FIFO-matched) for this symbol
+    const closedPositions = stocksData.closed_positions ?
+        stocksData.closed_positions.filter(pos => pos.symbol === symbol) : [];
+    const totalPnl = closedPositions.reduce((sum, pos) => sum + pos.pnl, 0);
+
+    // Calculate shares traded (total buy + sell volume)
+    const sharesTraded = symbolOrders.reduce((sum, order) => sum + order.quantity, 0);
+
+    // Find largest win and loss
+    const largestWin = closedPositions.length > 0 ?
+        Math.max(...closedPositions.map(p => p.pnl)) : 0;
+    const largestLoss = closedPositions.length > 0 ?
+        Math.min(...closedPositions.map(p => p.pnl)) : 0;
+
+    // Set modal title
+    const modalTitle = document.getElementById('symbolModalTitle');
+    modalTitle.textContent = `Trading Summary - ${symbol}`;
+
+    let html = '';
+
+    // Summary section (styled like calendar modal)
+    html += `
+        <div style="margin-bottom: 20px; padding: 10px; background: #f5f5f5; border-radius: 4px;">
+            <strong>Symbol Summary:</strong> ${sharesTraded} shares traded
+            <br>
+            <strong>Realized P&L:</strong>
+            <span class="${totalPnl >= 0 ? 'profit' : 'loss'}">
+                ${totalPnl >= 0 ? '+' : ''}$${totalPnl.toFixed(2)}
+            </span>
+    `;
+
+    if (closedPositions.length > 0) {
+        html += `
+            <br>
+            <strong>Largest Win:</strong>
+            <span class="${largestWin >= 0 ? 'profit' : 'loss'}">
+                ${largestWin >= 0 ? '+' : ''}$${largestWin.toFixed(2)}
+            </span>
+            &nbsp;&nbsp;
+            <strong>Largest Loss:</strong>
+            <span class="${largestLoss >= 0 ? 'profit' : 'loss'}">
+                ${largestLoss >= 0 ? '+' : ''}$${largestLoss.toFixed(2)}
+            </span>
+        `;
+    }
+
+    html += '</div>';
+
+    // Closed positions table (FIFO-matched trades)
+    if (closedPositions.length > 0) {
+        html += `
+            <h3>Closed Positions (${closedPositions.length})</h3>
+            <div style="max-height: 300px; overflow-y: auto; border: 1px solid #ddd; border-radius: 4px;">
+                <table class="position-details-table">
+                    <thead>
+                        <tr>
+                            <th>Buy Date</th>
+                            <th>Sell Date</th>
+                            <th>Quantity</th>
+                            <th>Avg Buy Price</th>
+                            <th>Avg Sell Price</th>
+                            <th>P&L</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+        `;
+
+        closedPositions.forEach(pos => {
+            const pnlClass = pos.pnl >= 0 ? 'profit' : 'loss';
+            const pnlSign = pos.pnl >= 0 ? '+' : '';
+
+            html += `
+                <tr>
+                    <td>${pos.buy_date}</td>
+                    <td>${pos.sell_date}</td>
+                    <td>${pos.quantity}</td>
+                    <td>$${pos.buy_price.toFixed(2)}</td>
+                    <td>$${pos.sell_price.toFixed(2)}</td>
+                    <td class="${pnlClass}">${pnlSign}$${pos.pnl.toFixed(2)}</td>
+                </tr>
+            `;
+        });
+
+        html += `
+                    </tbody>
+                </table>
+            </div>
+            <br>
+        `;
+    }
+
+    // All orders section - scrollable
+    html += `
+        <h3>All Orders (${symbolOrders.length})</h3>
+        <div style="max-height: 300px; overflow-y: auto; border: 1px solid #ddd; border-radius: 4px;">
+            <table class="position-details-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Side</th>
+                        <th>Quantity</th>
+                        <th>Price</th>
+                        <th>Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+    `;
+
+    symbolOrders.forEach(order => {
+        const date = new Date(order.last_transaction_at).toLocaleDateString();
+        const sideClass = order.side === 'buy' ? 'buy' : 'sell';
+
+        html += `
+            <tr>
+                <td>${date}</td>
+                <td class="${sideClass}">${order.side.toUpperCase()}</td>
+                <td>${order.quantity}</td>
+                <td>$${order.average_price.toFixed(2)}</td>
+                <td>$${order.total_amount.toFixed(2)}</td>
+            </tr>
+        `;
+    });
+
+    html += `
+                </tbody>
+            </table>
+        </div>
+    `;
+
+    // Show modal
+    document.getElementById('symbolModalTrades').innerHTML = html;
+    document.getElementById('symbolModal').style.display = 'block';
+}
+
 function showLoading(message = 'Loading...') {
     document.getElementById('loadingIndicator').textContent = message;
     document.getElementById('loadingIndicator').style.display = 'block';
@@ -448,12 +657,10 @@ function applyDateFilter() {
 }
 
 function clearDateFilter() {
-    document.getElementById('startDate').value = '';
-    document.getElementById('endDate').value = '';
     currentFilter.startDate = null;
     currentFilter.endDate = null;
 
-    // Re-render with all data
+    // Re-render with all data (this will reset the date inputs to first/last trade dates)
     renderFilteredData();
 }
 
@@ -475,8 +682,8 @@ function renderFilteredData() {
     // Calculate filtered summary stats
     const filteredSummary = calculateFilteredSummary(filteredClosed, filteredOrders);
 
-    // Re-render
-    renderSummary(filteredSummary);
+    // Re-render with filtered data
+    renderSummary(filteredSummary, filteredOrders);
     renderClosedPositions(filteredClosed);
     renderBySymbol(filteredClosed);
     renderOrders(filteredOrders);

--- a/stocks/templates/index.html
+++ b/stocks/templates/index.html
@@ -53,7 +53,26 @@
 
             <!-- By Symbol Tab -->
             <div id="bySymbol" class="tab-content">
-                <!-- Symbol P&L table will be inserted here -->
+                <h2>P&L by Symbol</h2>
+                <div class="sub-tabs">
+                    <div class="sub-tab active" data-subtab="table">Table</div>
+                    <div class="sub-tab" data-subtab="heatmap">Heat Map</div>
+                </div>
+                <div id="table" class="sub-tab-content active">
+                    <!-- Table will be inserted here -->
+                </div>
+                <div id="heatmap" class="sub-tab-content">
+                    <!-- Heatmap will be inserted here -->
+                </div>
+
+                <!-- Symbol Detail Modal -->
+                <div id="symbolModal" class="modal" style="display: none;">
+                    <div class="modal-content">
+                        <span class="close" id="symbolModalClose">&times;</span>
+                        <h2 id="symbolModalTitle"></h2>
+                        <div id="symbolModalTrades"></div>
+                    </div>
+                </div>
             </div>
 
             <!-- All Orders Tab -->


### PR DESCRIPTION
- Add nested tabs to "By Symbol" view (Table and Heat Map)
- Make table rows and heatmap boxes clickable to show symbol details
- Add symbol detail modal with FIFO-matched closed positions summary
- Display largest win/loss and total shares traded per symbol
- Populate date filters with first trade date and today's date
- Add scrollable sections for closed positions and all orders
- Match calendar modal styling for consistent UX